### PR TITLE
Total distinct annotations plus per label kappa matrix for annotation agreement

### DIFF
--- a/ar/data.py
+++ b/ar/data.py
@@ -1,9 +1,16 @@
 import os
 import shutil
+import itertools
 import re
 import glob
 import time
 from collections import defaultdict, Counter
+import logging
+
+import pandas as pd
+from flask import app
+from pandas import DataFrame
+from sklearn.metrics import cohen_kappa_score
 
 from shared.utils import save_jsonl, load_json, save_json, mkf, mkd
 from db.task import Task, DIR_ANNO, DIR_AREQ
@@ -212,8 +219,11 @@ def compute_annotation_statistics(task_id):
         _get_all_annotators_from_annotated(task_id)
     )
 
+    total_non_overlapping_annotations = set()
+
     for user_id in user_ids:
         anno_ids = fetch_all_annotations(task_id, user_id)
+        total_non_overlapping_annotations.update(anno_ids)
         n_annotations_per_user[user_id] = len(anno_ids)
 
         # TODO: slow
@@ -227,14 +237,124 @@ def compute_annotation_statistics(task_id):
         n_outstanding_requests_per_user[user_id] = len(
             set(ar_ids) - set(anno_ids))
 
+    # kappa stats calculation
+    kappa_table_per_label = _calculate_per_label_kappa_stats(
+        task_id, user_ids, total_non_overlapping_annotations)
+
     return {
         'total_annotations': sum(n_annotations_per_user.values()),
+        'total_non_overlapping_annotations': len(total_non_overlapping_annotations),
         'n_annotations_per_user': n_annotations_per_user,
         'n_annotations_per_label': n_annotations_per_label,
-
+        'kappa_table_per_label': kappa_table_per_label,
         'total_outstanding_requests': sum(n_outstanding_requests_per_user.values()),
         'n_outstanding_requests_per_user': n_outstanding_requests_per_user,
     }
+
+
+def _calculate_per_label_kappa_stats(task_id, user_ids,
+                                     total_non_overlapping_annotations):
+    """
+    Structure of the labeling results per label per user for the same set
+    of annotations:
+
+    {
+        "label1": {
+            "user_id1": [1, -1, 1, 1, -1],
+            "user_id2": [-1, 1, 1, -1, 1],
+            ...
+        },
+        "label12": {
+            "user_id1": [1, -1, 1, -1, 1],
+            "user_id2": [1, -1, -1, 1, 1],
+            ...
+        },
+        ...
+    }
+
+    Structure of the final output
+    {
+        "label": a matrix of kappa stats in the form of another dict,
+        ...
+    }
+    """
+    kappa_stats_raw_data = _construct_per_label_per_user_result(
+        task_id,
+        user_ids,
+        total_non_overlapping_annotations
+    )
+    user_ids.add("fake_user")
+    kappa_dataframe = _compute_kappa_matrix(user_ids, kappa_stats_raw_data)
+
+    return kappa_dataframe
+
+
+def _compute_kappa_matrix(user_ids, kappa_stats_raw_data):
+    """Structure of the final output
+    {
+        "label": a matrix of kappa stats in the form of another dict,
+        ...
+    }
+    """
+    all_pairs_of_users = list(itertools.combinations(user_ids, 2))
+    kappa_matrix = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(float)))
+    for label, result_per_label in kappa_stats_raw_data.items():
+        for user_pair in all_pairs_of_users:
+            result_user1 = result_per_label[user_pair[0]]
+            result_user2 = result_per_label[user_pair[1]]
+            kappa_score = cohen_kappa_score(result_user1, result_user2)
+            kappa_matrix[label][user_pair[0]][user_pair[1]] = kappa_score
+            kappa_matrix[label][user_pair[1]][user_pair[0]] = kappa_score
+            kappa_matrix[label][user_pair[0]][user_pair[0]] = 1
+            kappa_matrix[label][user_pair[1]][user_pair[1]] = 1
+
+    logging.error(kappa_matrix)
+
+    kappa_dataframe = defaultdict(str)
+    for label, nested_dict in kappa_matrix.items():
+        kappa_dataframe[label] = pd.DataFrame.from_dict(nested_dict)\
+            .to_html(classes='kappa_table')
+    logging.error(kappa_dataframe)
+
+    return kappa_dataframe
+
+
+def _construct_per_label_per_user_result(task_id, user_ids,
+                                         total_non_overlapping_annotations):
+    """
+    Structure of the labeling results per label per user for the same set
+    of annotations:
+
+    {
+        "label1": {
+            "user_id1": [1, -1, 1, 1, -1],
+            "user_id2": [-1, 1, 1, -1, 1],
+            ...
+        },
+        "label12": {
+            "user_id1": [1, -1, 1, -1, 1],
+            "user_id2": [1, -1, -1, 1, 1],
+            ...
+        },
+        ...
+    }
+    """
+    logging.error("Construct raw data===================================")
+    kappa_stats_raw_data = defaultdict(lambda: defaultdict(lambda: []))
+    for anno_id in total_non_overlapping_annotations:
+        for user_id in user_ids:
+            anno = fetch_annotation(task_id, user_id, anno_id)
+            for label, result in anno['anno']['labels'].items():
+                kappa_stats_raw_data[label][user_id].append(result)
+
+    kappa_stats_raw_data["HEALTHCARE"]["fake_user"] = [1] * len(kappa_stats_raw_data["HEALTHCARE"]["jzhang"])
+    kappa_stats_raw_data["HEALTHCARE"]["fake_user"][0] = -1
+    kappa_stats_raw_data["HEALTHCARE"]["fake_user"][2] = -1
+
+    logging.error(kappa_stats_raw_data)
+    logging.error("Construct raw data Finished===================================")
+    return kappa_stats_raw_data
 
 
 def _majority_label(labels):

--- a/backend/templates/tasks/show.html
+++ b/backend/templates/tasks/show.html
@@ -110,7 +110,7 @@
                 Total Annotated: {{annotation_statistics['total_annotations']}}
               </li>
               <li>
-                  Total Non-Overlapping Annotated: {{annotation_statistics['total_non_overlapping_annotations']}}
+                  Total Distinct Annotated: {{annotation_statistics['total_distinct_annotations']}}
               </li>
               <li>
                 Annotated per label:
@@ -128,6 +128,7 @@
                     <span class='badge badge-pill badge-info'>{{resp}}</span>x{{n}}
                     {% endif %}
                     {% endfor %}
+                  </li>
                   </li>
                   {% endfor %}
                 </ul>

--- a/backend/templates/tasks/show.html
+++ b/backend/templates/tasks/show.html
@@ -110,6 +110,9 @@
                 Total Annotated: {{annotation_statistics['total_annotations']}}
               </li>
               <li>
+                  Total Non-Overlapping Annotated: {{annotation_statistics['total_non_overlapping_annotations']}}
+              </li>
+              <li>
                 Annotated per label:
                 <ul>
                   {% for k in annotation_statistics['n_annotations_per_label'] %}
@@ -140,6 +143,20 @@
                 </ul>
               </li>
             </ul>
+          </div>
+        </div>
+
+       <div class="row">
+          <div class="col">
+            <h6>Annotator Kappa Score Matrix Per Label</h6>
+                <div>
+                  {% for k in annotation_statistics['kappa_table_per_label'] %}
+                  <div>
+                    <b>{{k}}</b>
+                    {{annotation_statistics['kappa_table_per_label'][k] | safe}}
+                  </div>
+                  {% endfor %}
+                </div>
           </div>
         </div>
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update
 RUN apt-get install -y redis-server vim
 
 RUN pip install redis pytest Flask supervisor Celery seaborn simpletransformers python-dotenv Flask-HTTPAuth
+RUN pip install mockito
 # Some error with latest pillow verison... downgrade pillow
 RUN conda install pillow=6.1
 

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,0 +1,81 @@
+from ar.data import _compute_kappa_matrix
+from ar.data import _construct_per_label_per_user_result
+import ar
+
+from mockito import when2, unstub
+
+
+def test_compute_kappa_matrix():
+    raw_data = {
+        "label1": {
+            "user_id1": [1, -1, 1, 1, -1],
+            "user_id2": [-1, 1, 1, -1, 1],
+        },
+        "label12": {
+            "user_id1": [1, -1, 1, -1, 1],
+            "user_id2": [1, -1, -1, 1, 1],
+        },
+    }
+    user_ids = ["user_id1", "user_id2"]
+    kappa_matrix = _compute_kappa_matrix(
+        user_ids=user_ids,
+        kappa_stats_raw_data=raw_data
+    )
+    assert(len(kappa_matrix) == len(raw_data))
+    for label in kappa_matrix:
+        matrix_per_label = kappa_matrix[label]
+        assert (len(matrix_per_label) == len(user_ids))
+        for user in matrix_per_label:
+            assert(len(matrix_per_label[user]) == len(user_ids))
+            assert(matrix_per_label[user][user] == 1)
+
+
+def test_construct_per_label_per_user_result():
+    task_id = "FakeId"
+    user_ids = ["User1", "User2"]
+    labels = ["HEALTHCARE", "B2C"]
+    annotation_ids = ["annotation1", "annotation2"]
+    annotations = [
+        {
+            "anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}
+        },
+        {
+            "anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}
+        },
+        {
+            "anno": {"labels": {"HEALTHCARE": 1, "B2C": 1}}
+        },
+        {
+            "anno": {"labels": {"HEALTHCARE": -1, "B2C": -1}}
+        }
+    ]
+
+    when2(ar.data.fetch_annotation, task_id, user_ids[0], annotation_ids[0])\
+        .thenReturn(annotations[0])
+    when2(ar.data.fetch_annotation, task_id, user_ids[0], annotation_ids[1]) \
+        .thenReturn(annotations[1])
+    when2(ar.data.fetch_annotation, task_id, user_ids[1], annotation_ids[0]) \
+        .thenReturn(annotations[2])
+    when2(ar.data.fetch_annotation, task_id, user_ids[1], annotation_ids[1]) \
+        .thenReturn(annotations[3])
+
+    kappa_stats_raw_data = _construct_per_label_per_user_result(
+        task_id,
+        user_ids,
+        annotation_ids
+    )
+
+    for label in labels:
+        assert label in kappa_stats_raw_data
+        for user in user_ids:
+            assert user in kappa_stats_raw_data[label]
+            if label == labels[0] and user == user_ids[0]:
+                assert kappa_stats_raw_data[label][user] == [-1, 1]
+            elif label == labels[0] and user == user_ids[1]:
+                assert kappa_stats_raw_data[label][user] == [1, -1]
+            elif label == labels[1] and user == user_ids[0]:
+                assert kappa_stats_raw_data[label][user] == [1, -1]
+            else:
+                assert kappa_stats_raw_data[label][user] == [1, -1]
+
+    unstub()


### PR DESCRIPTION
I changed the name from non-overlapping annotations to distinct annotations since I feel non-overlapping has some ambiguity with the use of `set` in the code (I kept thinking about the meaning of exclusion with non-overlapping).

For the kappa matrices, I think I'm missing a file so I have to hardcode a fake user during testing to see the changes on the front end. 

See the error below on the missing file:
```
    return self.run(*args, **kwargs)
  File "/annotation_tool/ar/ar_celery.py", line 32, in generate_annotation_requests
    res = _generate_annotation_requests(task_id, max_per_annotator, max_per_dp)
  File "/annotation_tool/ar/__init__.py", line 42, in generate_annotation_requests
    _get_predictions(task.get_full_data_fnames(), [_patterns_model])
  File "/annotation_tool/ar/__init__.py", line 166, in _get_predictions
    res = get_predicted(fname, model, cache=cache)
  File "/annotation_tool/inference/__init__.py", line 27, in get_predicted
    return _predict(data_fname, model)
  File "/annotation_tool/inference/__init__.py", line 11, in _predict
    res = model.predict(df['text'])
  File "/annotation_tool/inference/pattern_model.py", line 48, in predict
    self._load()
  File "/annotation_tool/inference/pattern_model.py", line 40, in _load
    raise Exception(f"Cannot load pattern: {row['pattern']}")
Exception: Cannot load pattern: [{'lower': 'health'}]
``` 