### PR TITLE
Adding a pytest.ini to exclude unnecessary test directory discovery

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# content of pytest.ini
+[pytest]
+norecursedirs = alchemy_bring_your_own_model/container/local_test


### PR DESCRIPTION
Adding the pytest.ini file to exclude the performance test script in the hosting service folder as it is only supposed to be executed there as an local integration test with a docker container running.