### PR TITLE
Change the pattern model to return the non-overlapping matches that maximizes the score

### DIFF
--- a/inference/pattern_model.py
+++ b/inference/pattern_model.py
@@ -14,15 +14,15 @@ def _compare_matches(item1, item2):
     :return: comparison result where -1 means item1 < item2, 1 means item1 >
     item2 and 0 means item1 == item2
     """
-    if (item1[2] - item1[1]) < (item2[2] - item2[1]):
+    if item1[1] < item2[1]:
         return -1
-    elif (item1[2] - item1[1]) > (item2[2] - item2[1]):
+    elif item1[1] > item2[1]:
         return 1
     else:
-        return _compare_last_matching_index(item1, item2)
+        return _compare_match_length(item1, item2)
 
 
-def _compare_last_matching_index(item1, item2):
+def _compare_match_length(item1, item2):
     """Compare two matches from the Pattern Matcher by the last matching index.
 
     :param item1: first matches item
@@ -30,12 +30,41 @@ def _compare_last_matching_index(item1, item2):
     :return: comparison result where -1 means item1 < item2, 1 means item1 >
     item2 and 0 means item1 == item2
     """
-    if item1[2] < item2[2]:
+    if (item1[2] - item1[1]) < (item2[2] - item2[1]):
         return -1
-    elif item1[2] > item2[2]:
+    elif (item1[2] - item1[1]) > (item2[2] - item2[1]):
         return 1
     else:
         return 0
+
+
+def _maximize_non_overlapping_matches(matches):
+    # All matches are sorted in ascending order by their first matching index
+    # and then by the length of the match.
+    matches.sort(key=cmp_to_key(_compare_matches))
+    len_of_matches = [m[2] - m[1] for m in matches]
+
+    selected_matches = set()
+    i = 0
+    j = i + 1
+    while i < len(matches) - 1 and j < len(matches):
+        match_left = matches[i]
+        match_right = matches[j]
+        if len_of_matches[i] <= len_of_matches[j]:
+            if match_left[2] <= match_right[1]:
+                # [1, 2) vs [3, 5) then we can safely add [1, 2)
+                # [1, 2) vs [2, 5) we can still safely add [1. 2)
+                selected_matches.add(match_left)
+            i = j
+        else:
+            if match_left[2] <= match_right[1]:
+                # [1, 2) vs [3, 5) then we can safely add [1, 2)
+                # [1, 2) vs [2, 5) we can still safely add [1. 2)
+                selected_matches.add(match_left)
+                i = j
+        j += 1
+    selected_matches.add(matches[i])
+    return selected_matches
 
 
 class PatternModel(ITextCatModel):
@@ -95,28 +124,24 @@ class PatternModel(ITextCatModel):
         # TODO disable the right things for speed
         for doc in self.nlp.pipe(text_list, disable=["tagger", "parser"]):
             matches = self.matcher(doc)
-            matches.sort(key=cmp_to_key(_compare_matches))
+            selected_matches = _maximize_non_overlapping_matches(matches)
             # m[2] and m[1] are start and end of matches
-            len_of_matches = [m[2] - m[1] for m in matches]
-            scores = [length / len(doc) if len(doc) > 0 else 0.
-                      for length in len_of_matches]
-            scores.sort()
+            len_of_matches = [m[2] - m[1] for m in selected_matches]
+            score = sum(len_of_matches) / len(doc) if len(doc) > 0 else 0.
 
-            # Here we extract the longest match only.
-            matches = matches[-1:]
             if fancy:
                 _matches = []
-                for match_id, start, end in matches:
+                for match_id, start, end in selected_matches:
                     span = doc[start:end]
                     _matches.append((start, end, span.text))
                 res.append({
                     'tokens': [str(x) for x in list(doc)],
                     'matches': _matches,
-                    'score': scores[-1]
+                    'score': score
                 })
             else:
                 res.append({
-                    'score': scores[-1]
+                    'score': score
                 })
 
         return res

--- a/inference/pattern_model.py
+++ b/inference/pattern_model.py
@@ -1,8 +1,41 @@
+from functools import cmp_to_key
 from typing import List
 import spacy
 # from spacy.matcher import Matcher
 from spacy.matcher import PhraseMatcher
 from .base import ITextCatModel
+
+
+def _compare_matches(item1, item2):
+    """Compare two matches from the Pattern Matcher by match length.
+
+    :param item1: first matched item
+    :param item2: second matched item
+    :return: comparison result where -1 means item1 < item2, 1 means item1 >
+    item2 and 0 means item1 == item2
+    """
+    if (item1[2] - item1[1]) < (item2[2] - item2[1]):
+        return -1
+    elif (item1[2] - item1[1]) > (item2[2] - item2[1]):
+        return 1
+    else:
+        return _compare_last_matching_index(item1, item2)
+
+
+def _compare_last_matching_index(item1, item2):
+    """Compare two matches from the Pattern Matcher by the last matching index.
+
+    :param item1: first matches item
+    :param item2: second matches item
+    :return: comparison result where -1 means item1 < item2, 1 means item1 >
+    item2 and 0 means item1 == item2
+    """
+    if item1[2] < item2[2]:
+        return -1
+    elif item1[2] > item2[2]:
+        return 1
+    else:
+        return 0
 
 
 class PatternModel(ITextCatModel):
@@ -25,11 +58,11 @@ class PatternModel(ITextCatModel):
     def _load(self):
         if not self._loaded:
             nlp = spacy.load("en_core_web_sm")
-            #matcher = Matcher(nlp.vocab)
+            # matcher = Matcher(nlp.vocab)
             matcher = PhraseMatcher(nlp.vocab)
 
             for row in self.spacy_patterns:
-                #matcher.add(row['label'], None, row['pattern'])
+                # matcher.add(row['label'], None, row['pattern'])
 
                 # TODO temporary fix:
                 # Assuming it's of the form "pattern": [{"lower": "my phrase"}]
@@ -45,6 +78,13 @@ class PatternModel(ITextCatModel):
             self._loaded = True
 
     def predict(self, text_list: List[str], fancy=False) -> List:
+        """Predict the match and score given the provided patterns.
+
+        :param text_list: a list of text
+        :param fancy: whether to return token and matched text in addition to a
+        matching score
+        :return: the longest and last match
+        """
         self._load()
 
         res = []
@@ -55,11 +95,15 @@ class PatternModel(ITextCatModel):
         # TODO disable the right things for speed
         for doc in self.nlp.pipe(text_list, disable=["tagger", "parser"]):
             matches = self.matcher(doc)
-
+            matches.sort(key=cmp_to_key(_compare_matches))
             # m[2] and m[1] are start and end of matches
             len_of_matches = [m[2] - m[1] for m in matches]
-            score = sum(len_of_matches) / len(doc) if len(doc) > 0 else 0.
+            scores = [length / len(doc) if len(doc) > 0 else 0.
+                      for length in len_of_matches]
+            scores.sort()
 
+            # Here we extract the longest match only.
+            matches = matches[-1:]
             if fancy:
                 _matches = []
                 for match_id, start, end in matches:
@@ -68,11 +112,11 @@ class PatternModel(ITextCatModel):
                 res.append({
                     'tokens': [str(x) for x in list(doc)],
                     'matches': _matches,
-                    'score': score
+                    'score': scores[-1]
                 })
             else:
                 res.append({
-                    'score': score
+                    'score': scores[-1]
                 })
 
         return res

--- a/tests/unit/test_pattern_model.py
+++ b/tests/unit/test_pattern_model.py
@@ -1,4 +1,9 @@
-from inference.pattern_model import PatternModel
+from functools import cmp_to_key
+
+from inference.pattern_model import PatternModel, \
+    _maximize_non_overlapping_matches, _compare_matches
+
+import pytest
 
 
 def test_pattern_model():
@@ -15,16 +20,64 @@ def test_pattern_model():
 
 def test_pattern_model_phrase():
     patterns = [
-        {"label": "HEALTHCARE", "pattern": [{"lower": "is healthy"}]},
-        {"label": "HEALTHCARE", "pattern": [{"lower": "dog"}]},
-        {"label": "HEALTHCARE", "pattern": [{"lower": "dog is"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "my"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "dog is healthy"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "and happy"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "healthy and happy"}]},
     ]
 
     model = PatternModel(patterns)
+    preds = model.predict(['my dog is healthy and happy'], fancy=True)
+    assert preds == [{'tokens': ['my', 'dog', 'is', 'healthy', 'and', 'happy'],
+                      'matches': [(0, 1, 'my'), (3, 6, 'healthy and happy')],
+                      'score': 4.0 / 6}]
 
-    preds = model.predict(['my dog is healthy'], fancy=False)
-    assert preds == [{'score': 0.5}]
 
-    preds_fancy = model.predict(['my dog is healthy'], fancy=True)
-    assert preds_fancy == [{'tokens': ['my', 'dog', 'is', 'healthy'],
-                            'matches': [(2, 4, 'is healthy')], 'score': 0.5}]
+@pytest.mark.parametrize(
+    "matches,expected",
+    [
+        ([("", 3, 4), ("", 1, 2)], [("", 1, 2), ("", 3, 4)]),
+        ([("", 3, 5), ("", 1, 2)], [("", 1, 2), ("", 3, 5)]),
+        ([("", 3, 5), ("", 1, 6)], [("", 1, 6), ("", 3, 5)]),
+        ([("", 3, 5), ("", 3, 6)], [("", 3, 5), ("", 3, 6)]),
+        ([("", 3, 7), ("", 3, 5)], [("", 3, 5), ("", 3, 7)]),
+        ([("", 3, 5), ("", 3, 5)], [("", 3, 5), ("", 3, 5)]),
+    ])
+def test_compare_matches(matches, expected):
+    # format: ("", match_start_index, match_end_index_exclusive)
+    sorted_matches = sorted(matches, key=cmp_to_key(_compare_matches))
+    assert sorted_matches == expected
+
+
+def test_maximize_non_overlapping_matches():
+    # format: ("", match_start_index, match_end_index_exclusive)
+    matches = [
+        ("", 1, 2),
+        ("", 2, 3),
+        ("", 2, 4),
+        ("", 3, 5),
+        ("", 4, 5),
+        ("", 4, 6),
+        ("", 8, 9)
+    ]
+    selected_matches = _maximize_non_overlapping_matches(matches=matches)
+    assert selected_matches == {
+        ("", 1, 2),
+        ("", 4, 6),
+        ("", 8, 9)
+    }
+
+    matches2 = [
+        ("", 1, 2),
+        ("", 2, 3),
+        ("", 2, 4),
+        ("", 3, 4),
+        ("", 3, 5),
+        ("", 4, 5),
+        ("", 4, 6),
+    ]
+    selected_matches = _maximize_non_overlapping_matches(matches=matches2)
+    assert selected_matches == {
+        ("", 1, 2),
+        ("", 4, 6),
+    }

--- a/tests/unit/test_pattern_model.py
+++ b/tests/unit/test_pattern_model.py
@@ -15,10 +15,16 @@ def test_pattern_model():
 
 def test_pattern_model_phrase():
     patterns = [
-        {"label": "HEALTHCARE", "pattern": [{"lower": "dog is healthy"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "is healthy"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "dog"}]},
+        {"label": "HEALTHCARE", "pattern": [{"lower": "dog is"}]},
     ]
 
     model = PatternModel(patterns)
-    preds = model.predict(['my dog is healthy'], fancy=True)
-    assert preds == [{'tokens': ['my', 'dog', 'is', 'healthy'],
-                      'matches': [(1, 4, 'dog is healthy')], 'score': 0.75}]
+
+    preds = model.predict(['my dog is healthy'], fancy=False)
+    assert preds == [{'score': 0.5}]
+
+    preds_fancy = model.predict(['my dog is healthy'], fancy=True)
+    assert preds_fancy == [{'tokens': ['my', 'dog', 'is', 'healthy'],
+                            'matches': [(2, 4, 'is healthy')], 'score': 0.5}]


### PR DESCRIPTION
The pattern matcher returns a list of all matches and it seems they are always ordered in ascending order by the length of match. To be less dependent on the API, I added a few lines of code to sort the result in ascending order. The result has the same format but only contains the largest and last matching result. For example, if the patterns are:
```
my
dog is healthy
healthy and happy
```
and the text is `my dog is healthy and happy`, then the return value is:
```
[{'tokens': ['my', 'dog', 'is', 'healthy', 'and', 'happy'],
   'matches': [(0, 1, 'my'), (3, 6, 'healthy and happy')], 'score': 4.0 / 6}]
```
The maximize method should cover all edge cases and it is cleaned up. If it doesn't make sense to you, I can share a super verbose version that has all the redundant if-else statements. That is the longest if-else statements I've written in years...