### PR TITLE
Add edge case for empty matches

### DIFF
--- a/inference/pattern_model.py
+++ b/inference/pattern_model.py
@@ -41,6 +41,8 @@ def _compare_match_length(item1, item2):
 def _maximize_non_overlapping_matches(matches):
     # All matches are sorted in ascending order by their first matching index
     # and then by the length of the match.
+    if len(matches) == 0:
+        return {}
     matches.sort(key=cmp_to_key(_compare_matches))
     len_of_matches = [m[2] - m[1] for m in matches]
 

--- a/tests/unit/test_pattern_model.py
+++ b/tests/unit/test_pattern_model.py
@@ -81,3 +81,11 @@ def test_maximize_non_overlapping_matches():
         ("", 1, 2),
         ("", 4, 6),
     }
+
+    matches3 = []
+    selected_matches = _maximize_non_overlapping_matches(matches=matches3)
+    assert selected_matches == {}
+
+    matches4 = [("", 1, 2),]
+    selected_matches = _maximize_non_overlapping_matches(matches=matches4)
+    assert selected_matches == {("", 1, 2)}


### PR DESCRIPTION
Add a check for empty matches to avoid out of bound index error.

This covers the maximize function itself but not the predict function. We will need to add more unit tests for code coverage as a separate task.