### PR TITLE
Rewrite the kappa calculation

### DIFF
--- a/ar/__init__.py
+++ b/ar/__init__.py
@@ -10,8 +10,8 @@ from inference.base import ITextCatModel
 from inference import get_predicted
 from inference.random_model import RandomModel
 
-from .data import fetch_all_annotations
-from .utils import get_ar_id
+from .data import fetch_all_annotation_ids
+from .utils import get_ar_id, timeit
 
 Pred = namedtuple('Pred', ['score', 'fname', 'line_number'])
 
@@ -139,7 +139,7 @@ def generate_annotation_requests(task_id: str,
 
 def _build_blacklist_fn(task: Task):
     _lookup = {
-        user: set(fetch_all_annotations(task.task_id, user))
+        user: set(fetch_all_annotation_ids(task.task_id, user))
         for user in task.annotators
     }
 

--- a/ar/data.py
+++ b/ar/data.py
@@ -107,7 +107,7 @@ def get_next_ar(task_id, user_id, ar_id):
         - If nothing left to label, return None
     '''
     ar_all = fetch_all_ar(task_id, user_id)
-    ar_done = set(fetch_all_annotations(task_id, user_id))
+    ar_done = set(fetch_all_annotation_ids(task_id, user_id))
 
     try:
         idx = ar_all.index(ar_id)
@@ -165,7 +165,7 @@ def fetch_annotation(task_id, user_id, ar_id):
         return None
 
 
-def fetch_all_annotations(task_id, user_id):
+def fetch_all_annotation_ids(task_id, user_id):
     '''
     Return a list of ar_id for this task that has been annotated by this user.
     '''
@@ -225,7 +225,7 @@ def compute_annotation_statistics(task_id):
     results_per_task_user_anno_id = dict()
 
     for user_id in user_ids:
-        anno_ids = fetch_all_annotations(task_id, user_id)
+        anno_ids = fetch_all_annotation_ids(task_id, user_id)
         anno_ids_per_user[user_id] = set(anno_ids)
         n_annotations_per_user[user_id] = len(anno_ids)
 
@@ -492,7 +492,7 @@ def _export_distinct_labeled_examples(annotations_iterator):
                 }
             },
             'anno': {
-                'labels': {ƒ
+                'labels': {
                     'HEALTHCARE': 1,
                     'POP_HEALTH': -1,
                     'AI': 0,
@@ -569,7 +569,7 @@ def _export_distinct_labeled_examples(annotations_iterator):
 def _gather_distinct_labeled_examples(task_id):
     def annotations_iterator():
         for user_id in _get_all_annotators_from_annotated(task_id):
-            for ar_id in fetch_all_annotations(task_id, user_id):
+            for ar_id in fetch_all_annotation_ids(task_id, user_id):
                 anno = fetch_annotation(task_id, user_id, ar_id)
 
                 yield anno

--- a/ar/data.py
+++ b/ar/data.py
@@ -218,13 +218,12 @@ def compute_annotation_statistics(task_id):
         _get_all_annotators_from_annotated(task_id)
     )
 
-    total_distinct_annotations = set()
-    annotations_from_all_users = []
+    total_distinct_annotations = _gather_labeled_examples(task_id)
+    annotations_per_user = dict()
 
     for user_id in user_ids:
         anno_ids = fetch_all_annotations(task_id, user_id)
-        total_distinct_annotations.update(anno_ids)
-        annotations_from_all_users.append(set(anno_ids))
+        annotations_per_user[user_id] = set(anno_ids)
         n_annotations_per_user[user_id] = len(anno_ids)
 
         # TODO: slow
@@ -240,7 +239,7 @@ def compute_annotation_statistics(task_id):
 
     # kappa stats calculation
     kappa_table_per_label = _calculate_per_label_kappa_stats_table(
-        task_id, user_ids, annotations_from_all_users)
+        task_id, user_ids, annotations_per_user)
 
     return {
         'total_annotations': sum(n_annotations_per_user.values()),
@@ -254,98 +253,130 @@ def compute_annotation_statistics(task_id):
 
 
 def _calculate_per_label_kappa_stats_table(task_id, user_ids,
-                                           annotations_from_all_users):
+                                           annotations_per_user):
     """Calculate per label kappa matrix stats.
+
+    Input structure of the annotations_per_user:
+    {
+        "user1": set(anno1, anno2, anno3, anno4),
+        "user2": set(anno2, anno3, anno5, anno8),
+        ...
+    }
 
     :param task_id: the id of a task
     :param user_ids: the user id list
-    :param annotations_from_all_users: annotations from all users
+    :param annotations_per_user: annotations per user dictionary
     :return: the per label kappa matrix html table
     """
     if len(user_ids) == 1:
         return ['There is only one user {}'.format(list(user_ids)[0])]
-    if len(annotations_from_all_users) == 0:
+    if len(annotations_per_user) == 0:
         return ['There are no annotations from any user yet.']
-    annotation_intersection = set.intersection(*annotations_from_all_users)
-    if len(annotation_intersection) == 0:
-        return ['No overlapping annotations found among users.']
-    kappa_stats_raw_data = _construct_per_label_per_user_result(
+    kappa_stats_raw_data = _construct_per_label_per_user_pair_result(
         task_id,
         user_ids,
-        annotation_intersection
+        annotations_per_user
     )
-
-
-    logging.info(kappa_stats_raw_data)
-    kappa_matrices = _compute_kappa_matrix(user_ids, kappa_stats_raw_data)
+    kappa_matrices = _compute_kappa_matrix(kappa_stats_raw_data)
     kappa_matrix_html_tables = _convert_html_tables(kappa_matrices)
     return kappa_matrix_html_tables
 
 
-def _convert_html_tables(kappa_matrices):
-    float_formatter = "{:.2f}".format
-    kappa_html_tables = defaultdict(str)
-    for label, df in kappa_matrices.items():
-        kappa_html_tables[label] = df.to_html(classes='kappa_table',
-                                              float_format=float_formatter)
-    return kappa_html_tables
-
-
-def _construct_per_label_per_user_result(task_id, user_ids,
-                                         annotation_intersection):
-    """Construct the per label per user labeling result dictionary.
+def _construct_per_label_per_user_pair_result(task_id, user_ids,
+                                              annotations_per_user):
+    """Construct the per label per user_pair labeling result dictionary.
 
     :param task_id: the id of a task
     :param user_ids: the user ids
-    :param annotation_intersection: annotation ids of intersected annotations
-    :return: a dictionary of per label per user labeling result
+    :param annotations_per_user: annotation ids of per user
+    :return: a dictionary of per label per user pair labeling result
 
-    Structure of the labeling results per label per user for the same set
-    of annotations:
+    Input structure of the annotations_per_user:
+    {
+        "user1": [anno1, anno2, anno3, anno4],
+        "user2": [anno2, anno3, anno5, anno8],
+        ...
+    }
 
+    Output structure of the labeling results per label per user_pair for the
+    same set of annotations:
     {
         "label1": {
-            "user_id1": [1, -1, 1, 1, -1],
-            "user_id2": [-1, 1, 1, -1, 1],
+            ("user_id1", "user_id2"): {
+                "user_id1": [1, -1, 1, 1, -1],
+                "user_id2": [-1, 1, 1, -1, 1]
+            },
+            ("user_id1", "user_id3"): {
+                "user_id1": [1, -1],
+                "user_id2": [-1, 1]
+            }
             ...
         },
         "label12": {
-            "user_id1": [1, -1, 1, -1, 1],
-            "user_id2": [1, -1, -1, 1, 1],
+            ("user_id1", "user_id3"): {
+                "user_id1": [1, -1],
+                "user_id2": [-1, 1]
+            },
             ...
         },
         ...
     }
     """
+    kappa_stats_raw_data = PrettyDefaultDict(
+        lambda: PrettyDefaultDict(lambda: PrettyDefaultDict(lambda: [])))
 
-    kappa_stats_raw_data = defaultdict(lambda: defaultdict(lambda: []))
-    for anno_id in annotation_intersection:
-        for user_id in user_ids:
-            anno = fetch_annotation(task_id, user_id, anno_id)
-            for label, result in anno['anno']['labels'].items():
-                kappa_stats_raw_data[label][user_id].append(result)
+    all_pairs_of_users = list(itertools.combinations(user_ids, 2))
+
+    for user1, user2 in all_pairs_of_users:
+        annotations_user1 = annotations_per_user[user1]
+        annotations_user2 = annotations_per_user[user2]
+
+        annotation_intersection = set.intersection(annotations_user1,
+                                                   annotations_user2)
+        # WE NEED TO SORT THIS. OTHERWISE WE GOT UNSTABLE OUTPUT WHICH FAILS
+        # UNIT TESTS!
+        for anno_id in sorted(annotation_intersection):
+            anno_by_user1 = fetch_annotation(task_id, user1, anno_id)
+            anno_by_user2 = fetch_annotation(task_id, user2, anno_id)
+
+            for label, result in anno_by_user1['anno']['labels'].items():
+                kappa_stats_raw_data[label][(user1, user2)][user1].append(
+                    result)
+
+            for label, result in anno_by_user2['anno']['labels'].items():
+                kappa_stats_raw_data[label][(user1, user2)][user2].append(
+                    result)
 
     return kappa_stats_raw_data
 
 
-def _compute_kappa_matrix(user_ids, kappa_stats_raw_data):
+def _compute_kappa_matrix(kappa_stats_raw_data):
     """Compute the kappa matrix for each label and return the html form of the
     matrix.
 
     :param user_ids: the user ids
-    :param kappa_stats_raw_data: raw labeling results per label per user
+    :param kappa_stats_raw_data: raw labeling results per label per user pair
+    on overlapping annotations
     :return: a dictionary of kappa matrix html table per label
 
     Structure of the input:
     {
         "label1": {
-            "user_id1": [1, -1, 1, 1, -1],
-            "user_id2": [-1, 1, 1, -1, 1],
+            ("user_id1", "user_id2"): {
+                "user_id1": [1, -1, 1, 1, -1],
+                "user_id2": [-1, 1, 1, -1, 1]
+            },
+            ("user_id1", "user_id3"): {
+                "user_id1": [1, -1],
+                "user_id2": [-1, 1]
+            }
             ...
         },
         "label12": {
-            "user_id1": [1, -1, 1, -1, 1],
-            "user_id2": [1, -1, -1, 1, 1],
+            ("user_id1", "user_id3"): {
+                "user_id1": [1, -1],
+                "user_id2": [-1, 1]
+            },
             ...
         },
         ...
@@ -353,29 +384,44 @@ def _compute_kappa_matrix(user_ids, kappa_stats_raw_data):
 
     Structure of the final output:
     {
-        "label": html table form of the kappa matrix for this label
+        "label1": kappa matrix for this label as a pandas dataframe,
+        "label2": kappa matrix for this label as a pandas dataframe,
         ...
     }
 
     """
-    all_pairs_of_users = list(itertools.combinations(user_ids, 2))
-    kappa_matrix = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(float)))
-    for label, result_per_label in kappa_stats_raw_data.items():
-        for user_pair in all_pairs_of_users:
-            result_user1 = result_per_label[user_pair[0]]
-            result_user2 = result_per_label[user_pair[1]]
+    kappa_matrix = PrettyDefaultDict(
+        lambda: PrettyDefaultDict(lambda: PrettyDefaultDict(float)))
+    for label, result_per_user_pair_per_label in kappa_stats_raw_data.items():
+        for user_pair, result_per_user in \
+                result_per_user_pair_per_label.items():
+            result_user1 = result_per_user[user_pair[0]]
+            result_user2 = result_per_user[user_pair[1]]
             kappa_score = cohen_kappa_score(result_user1, result_user2)
             kappa_matrix[label][user_pair[0]][user_pair[1]] = kappa_score
             kappa_matrix[label][user_pair[1]][user_pair[0]] = kappa_score
             kappa_matrix[label][user_pair[0]][user_pair[0]] = 1
             kappa_matrix[label][user_pair[1]][user_pair[1]] = 1
 
-    kappa_dataframe = defaultdict(DataFrame)
+    kappa_dataframe = PrettyDefaultDict(DataFrame)
     for label, nested_dict in kappa_matrix.items():
         kappa_dataframe[label] = pd.DataFrame.from_dict(nested_dict)
-
     return kappa_dataframe
+
+
+def _convert_html_tables(kappa_matrices):
+    float_formatter = "{:.2f}".format
+    kappa_html_tables = PrettyDefaultDict(str)
+    for label, df in kappa_matrices.items():
+        kappa_html_tables[label] = df.to_html(classes='kappa_table',
+                                              float_format=float_formatter)
+    return kappa_html_tables
+
+
+class PrettyDefaultDict(defaultdict):
+    """An wrapper around defaultdict so the print out looks like
+    a normal dict."""
+    __repr__ = dict.__repr__
 
 
 def _majority_label(labels):
@@ -479,7 +525,7 @@ def _export_labeled_examples(annotations_iterator):
     return final
 
 
-def export_labeled_examples(task_id, outfile=None):
+def _gather_labeled_examples(task_id):
     def annotations_iterator():
         for user_id in _get_all_annotators_from_annotated(task_id):
             for ar_id in fetch_all_annotations(task_id, user_id):
@@ -488,6 +534,11 @@ def export_labeled_examples(task_id, outfile=None):
                 yield anno
 
     final = _export_labeled_examples(annotations_iterator())
+    return final
+
+
+def export_labeled_examples(task_id, outfile=None):
+    final = _gather_labeled_examples(task_id)
 
     if outfile is not None:
         save_jsonl(outfile, final)

--- a/ar/utils.py
+++ b/ar/utils.py
@@ -1,7 +1,23 @@
 import hashlib
+import logging
+import time
 
 
 def get_ar_id(fname, line_number):
     ar_id = f'{fname}:{line_number}'
     ar_id = hashlib.sha224(ar_id.encode()).hexdigest()
     return ar_id
+
+
+def timeit(method):
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if 'log_time' in kw:
+            name = kw.get('log_name', method.__name__.upper())
+            kw['log_time'][name] = int((te - ts) * 1000)
+        else:
+            logging.error('%r %2.2f ms' % (method.__name__, (te - ts) * 1000))
+        return result
+    return timed

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -1,5 +1,5 @@
 from ar.data import (
-    fetch_all_ar, fetch_ar, fetch_annotation, fetch_all_annotations, get_next_ar,
+    fetch_all_ar, fetch_ar, fetch_annotation, fetch_all_annotation_ids, get_next_ar,
     build_empty_annotation, annotate_ar
 )
 import json
@@ -39,7 +39,7 @@ def show(id):
 
     task = Task.fetch(id)
     ars = fetch_all_ar(id, user_id)
-    annotated = set(fetch_all_annotations(id, user_id))
+    annotated = set(fetch_all_annotation_ids(id, user_id))
     has_annotation = [x in annotated for x in ars]
 
     et = time.time()

--- a/tests/integration/test_ar_flow.py
+++ b/tests/integration/test_ar_flow.py
@@ -6,7 +6,7 @@ from ar.data import (
     fetch_tasks_for_user,
     fetch_all_ar,
     fetch_ar,
-    fetch_all_annotations,
+    fetch_all_annotation_ids,
     fetch_annotation,
     annotate_ar,
     get_next_ar,
@@ -93,7 +93,7 @@ class TestARFlow:
         assert annotation_requests[2]['ar_id'] == all_ars[2]
 
         # User has not labeled anything yet.
-        assert len(fetch_all_annotations(task_id, user_id)) == 0
+        assert len(fetch_all_annotation_ids(task_id, user_id)) == 0
 
         ar_detail = fetch_ar(task_id, user_id, all_ars[0])
         assert ar_detail['ar_id'] == annotation_requests[0]['ar_id']
@@ -104,20 +104,20 @@ class TestARFlow:
         annotate_ar(task_id, user_id, all_ars[0], my_anno)
         assert fetch_annotation(task_id, user_id, all_ars[0])[
             'anno'] == my_anno
-        assert len(fetch_all_annotations(task_id, user_id)) == 1
+        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
 
         # Annotate the same thing again updates the annotation
         updated_anno = {'labels': {'FINTECH': 1, 'HEALTHCARE': 0}}
         annotate_ar(task_id, user_id, all_ars[0], updated_anno)
         assert fetch_annotation(task_id, user_id, all_ars[0])[
             'anno'] == updated_anno
-        assert len(fetch_all_annotations(task_id, user_id)) == 1
+        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
 
         # Annotate something that doesn't exist
         # (this might happen when master is updating - we'll try to avoid it)
         annotate_ar(task_id, user_id, 'doesnotexist',
                     {'labels': {'HEALTHCARE': 1}})
-        assert len(fetch_all_annotations(task_id, user_id)) == 1
+        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
 
         # Fetch next thing to be annotated
         # ar[0] is labeled, label ar[1]
@@ -170,7 +170,7 @@ class TestARFlow:
             fetch_all_ar(task_id, user_id))
 
         # Check existing annotations still exist
-        assert len(fetch_all_annotations(task_id, user_id)) == 1
+        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
 
         # Annotate something thing in the new batch
         my_anno = {'labels': {'MACHINELEARNING': 0,
@@ -179,7 +179,7 @@ class TestARFlow:
         annotate_ar(task_id, user_id, all_ars[0], my_anno)
         assert fetch_annotation(task_id, user_id, all_ars[0])[
             'anno'] == my_anno
-        assert len(fetch_all_annotations(task_id, user_id)) == 2
+        assert len(fetch_all_annotation_ids(task_id, user_id)) == 2
 
         # TODO: Write the test. When there is 1 thing left in queue, get_next_ar should return None.
         # assert get_next_ar(task_id, user_id, all_ars[-1]) == None

--- a/tests/integration/test_train_flow.py
+++ b/tests/integration/test_train_flow.py
@@ -4,7 +4,7 @@ from db.task import Task
 from ar.data import (
     save_new_ar_for_user,
     annotate_ar,
-    fetch_all_annotations
+    fetch_all_annotation_ids
 )
 from ar.utils import get_ar_id
 from train.prep import (
@@ -86,7 +86,7 @@ class TestTrainFlow:
 
     def test__test_setup_is_ok(self):
         task = self.task
-        assert len(fetch_all_annotations(task.task_id, 'eddie_test')) == 20
+        assert len(fetch_all_annotation_ids(task.task_id, 'eddie_test')) == 20
 
     def test__train_flow(self, tmpdir):
         task = self.task

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,26 +1,102 @@
-from ar.data import _compute_kappa_matrix, \
-    _calculate_per_label_kappa_stats_table
-from ar.data import _construct_per_label_per_user_result
-import ar
-import pytest
+import itertools
 
+import pytest
 from mockito import when2, unstub
 
+import ar
+from ar.data import _compute_kappa_matrix, \
+    _calculate_per_label_kappa_stats_table
+from ar.data import _construct_per_label_per_user_pair_result
 
-def test_compute_kappa_matrix():
+
+def test__construct_per_label_per_user_pair_result():
+    task_id = "fakeid"
+    user_ids = ["user1", "user2", "user3"]
+
+    annotations_per_user = {
+        "user1": {"a1", "a2", "a3"},
+        "user2": {"a1", "a3"},
+        "user3": {"a2", "a3"}
+    }
+
+    when2(ar.data.fetch_annotation, task_id, "user1", "a1") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+    when2(ar.data.fetch_annotation, task_id, "user1", "a2") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}})
+    when2(ar.data.fetch_annotation, task_id, "user1", "a3") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+
+    when2(ar.data.fetch_annotation, task_id, "user2", "a1") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+    when2(ar.data.fetch_annotation, task_id, "user2", "a2") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}})
+    when2(ar.data.fetch_annotation, task_id, "user2", "a3") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+
+    when2(ar.data.fetch_annotation, task_id, "user3", "a1") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+    when2(ar.data.fetch_annotation, task_id, "user3", "a2") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}})
+    when2(ar.data.fetch_annotation, task_id, "user3", "a3") \
+        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+
+    expected = {
+        "HEALTHCARE": {
+            ("user1", "user2"): {
+                "user1": [1, 1],
+                "user2": [1, 1]
+            },
+            ("user1", "user3"): {
+                "user1": [-1, 1],
+                "user3": [-1, 1]
+            },
+            ("user2", "user3"): {
+                "user2": [1],
+                "user3": [1]
+            }
+        },
+        "B2C": {
+            ("user1", "user2"): {
+                "user1": [-1, -1],
+                "user2": [-1, -1]
+            },
+            ("user1", "user3"): {
+                "user1": [1, -1],
+                "user3": [1, -1]
+            },
+            ("user2", "user3"): {
+                "user2": [-1],
+                "user3": [-1]
+            }
+        }
+    }
+
+    kappa_stats_raw_data = _construct_per_label_per_user_pair_result(
+        task_id=task_id, user_ids=user_ids,
+        annotations_per_user=annotations_per_user
+    )
+
+    assert kappa_stats_raw_data == expected
+    unstub()
+
+
+def test__compute_kappa_matrix():
     raw_data = {
         "label1": {
-            "user_id1": [1, -1, 1, 1, -1],
-            "user_id2": [-1, 1, 1, -1, 1],
+            ("user_id1", "user_id2"): {
+                "user_id1": [1, -1, 1, 1, -1],
+                "user_id2": [-1, 1, 1, -1, 1],
+            }
         },
-        "label12": {
-            "user_id1": [1, -1, 1, -1, 1],
-            "user_id2": [1, -1, -1, 1, 1],
+        "label2": {
+            ("user_id1", "user_id2"): {
+                "user_id1": [1, -1, 1, -1, 1],
+                "user_id2": [1, -1, -1, 1, 1],
+            }
         },
     }
     user_ids = ["user_id1", "user_id2"]
     kappa_matrix = _compute_kappa_matrix(
-        user_ids=user_ids,
         kappa_stats_raw_data=raw_data
     )
     assert (len(kappa_matrix) == len(raw_data))
@@ -32,75 +108,22 @@ def test_compute_kappa_matrix():
             assert (matrix_per_label[user][user] == 1)
 
 
-def test_construct_per_label_per_user_result():
-    task_id = "FakeId"
-    user_ids = ["User1", "User2"]
-    labels = ["HEALTHCARE", "B2C"]
-    annotation_ids = ["annotation1", "annotation2"]
-    annotations = [
-        {
-            "anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}
-        },
-        {
-            "anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}
-        },
-        {
-            "anno": {"labels": {"HEALTHCARE": 1, "B2C": 1}}
-        },
-        {
-            "anno": {"labels": {"HEALTHCARE": -1, "B2C": -1}}
-        }
-    ]
-
-    when2(ar.data.fetch_annotation, task_id, user_ids[0], annotation_ids[0]) \
-        .thenReturn(annotations[0])
-    when2(ar.data.fetch_annotation, task_id, user_ids[0], annotation_ids[1]) \
-        .thenReturn(annotations[1])
-    when2(ar.data.fetch_annotation, task_id, user_ids[1], annotation_ids[0]) \
-        .thenReturn(annotations[2])
-    when2(ar.data.fetch_annotation, task_id, user_ids[1], annotation_ids[1]) \
-        .thenReturn(annotations[3])
-
-    kappa_stats_raw_data = _construct_per_label_per_user_result(
-        task_id,
-        user_ids,
-        annotation_ids
-    )
-
-    for label in labels:
-        assert label in kappa_stats_raw_data
-        for user in user_ids:
-            assert user in kappa_stats_raw_data[label]
-            if label == labels[0] and user == user_ids[0]:
-                assert kappa_stats_raw_data[label][user] == [-1, 1]
-            elif label == labels[0] and user == user_ids[1]:
-                assert kappa_stats_raw_data[label][user] == [1, -1]
-            elif label == labels[1] and user == user_ids[0]:
-                assert kappa_stats_raw_data[label][user] == [1, -1]
-            else:
-                assert kappa_stats_raw_data[label][user] == [1, -1]
-
-    unstub()
-
-
-@pytest.mark.parametrize("task_id,user_ids,annotation_ids,expected",
+@pytest.mark.parametrize("task_id,user_ids,annotations_per_user,expected",
                          [
-                             ("FakeId", ["User1"], ["anno1", "anno2"],
+                             ("FakeId", ["User1"], {"User1": ["anno1",
+                                                              "anno2"]},
                               ["There is only one user User1"]),
-                             ("FakeId", ["User1", "User2"], [],
+                             ("FakeId", ["User1", "User2"], {},
                               ["There are no annotations from any user yet."]),
-                             ("FakeId", ["User1", "User2"], [{0}, {1}],
-                              ['No overlapping annotations found among users.'])
                          ]
                          )
-def test_calculate_per_label_kappa_stats_table_edge_cases(task_id, user_ids,
-                                                          annotation_ids,
+def test__calculate_per_label_kappa_stats_table_edge_cases(task_id, user_ids,
+                                                          annotations_per_user,
                                                           expected):
     kappa_matrix_html_tables = _calculate_per_label_kappa_stats_table(
         task_id,
         user_ids,
-        annotation_ids
+        annotations_per_user
     )
 
     assert kappa_matrix_html_tables == expected
-

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,11 +1,11 @@
-import itertools
+import math
 
 import pytest
 from mockito import when2, unstub
 
-import ar
 from ar.data import _compute_kappa_matrix, \
-    _calculate_per_label_kappa_stats_table
+    _calculate_per_label_kappa_stats_table, \
+    _exclude_unknowns_for_kappa_calculation
 from ar.data import _construct_per_label_per_user_pair_result
 
 
@@ -13,32 +13,32 @@ def test__construct_per_label_per_user_pair_result():
     task_id = "fakeid"
     user_ids = ["user1", "user2", "user3"]
 
-    annotations_per_user = {
+    anno_ids_per_user = {
         "user1": {"a1", "a2", "a3"},
         "user2": {"a1", "a3"},
         "user3": {"a2", "a3"}
     }
 
-    when2(ar.data.fetch_annotation, task_id, "user1", "a1") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
-    when2(ar.data.fetch_annotation, task_id, "user1", "a2") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}})
-    when2(ar.data.fetch_annotation, task_id, "user1", "a3") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
-
-    when2(ar.data.fetch_annotation, task_id, "user2", "a1") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
-    when2(ar.data.fetch_annotation, task_id, "user2", "a2") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}})
-    when2(ar.data.fetch_annotation, task_id, "user2", "a3") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
-
-    when2(ar.data.fetch_annotation, task_id, "user3", "a1") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
-    when2(ar.data.fetch_annotation, task_id, "user3", "a2") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": -1, "B2C": 1}}})
-    when2(ar.data.fetch_annotation, task_id, "user3", "a3") \
-        .thenReturn({"anno": {"labels": {"HEALTHCARE": 1, "B2C": -1}}})
+    results_per_task_user_anno_id = {
+        (task_id, "user1", "a1"): {"anno": {"labels": {"HEALTHCARE": 1,
+                                                       "B2C": -1}}},
+        (task_id, "user1", "a2"): {"anno": {"labels": {"HEALTHCARE": -1,
+                                                       "B2C": 1}}},
+        (task_id, "user1", "a3"): {"anno": {"labels": {"HEALTHCARE": 1,
+                                                       "B2C": -1}}},
+        (task_id, "user2", "a1"): {"anno": {"labels": {"HEALTHCARE": 1,
+                                                      "B2C": -1}}},
+        (task_id, "user2", "a2"): {"anno": {"labels": {"HEALTHCARE": -1,
+                                                       "B2C": 1}}},
+        (task_id, "user2", "a3"): {"anno": {"labels": {"HEALTHCARE": 1,
+                                                       "B2C": -1}}},
+        (task_id, "user3", "a1"): {"anno": {"labels": {"HEALTHCARE": 1,
+                                                       "B2C": -1}}},
+        (task_id, "user3", "a2"): {"anno": {"labels": {"HEALTHCARE": -1,
+                                                       "B2C": 1}}},
+        (task_id, "user3", "a3"): {"anno": {"labels": {"HEALTHCARE": 1,
+                                                       "B2C": -1}}},
+    }
 
     expected = {
         "HEALTHCARE": {
@@ -73,11 +73,26 @@ def test__construct_per_label_per_user_pair_result():
 
     kappa_stats_raw_data = _construct_per_label_per_user_pair_result(
         task_id=task_id, user_ids=user_ids,
-        annotations_per_user=annotations_per_user
+        annos_per_user=anno_ids_per_user,
+        results_per_task_user_anno_id=results_per_task_user_anno_id
     )
 
     assert kappa_stats_raw_data == expected
-    unstub()
+
+
+def test__exclude_unknowns_for_kappa_calculation():
+    input1 = [1, 1, 1, -1]
+    input2 = [-1, 1, 1, -1]
+
+    result1, result2 = _exclude_unknowns_for_kappa_calculation(input1, input2)
+    assert input1 == result1
+    assert input2 == result2
+
+    input1 = [1, 0, 1, 0]
+    input2 = [0, -1, -1, 0]
+    result1, result2 = _exclude_unknowns_for_kappa_calculation(input1, input2)
+    assert result1 == [1]
+    assert result2 == [-1]
 
 
 def test__compute_kappa_matrix():
@@ -108,22 +123,52 @@ def test__compute_kappa_matrix():
             assert (matrix_per_label[user][user] == 1)
 
 
-@pytest.mark.parametrize("task_id,user_ids,annotations_per_user,expected",
+def test__compute_kappa_matrix_unknown():
+    raw_data = {
+        "label1": {
+            ("user_id1", "user_id2"): {
+                "user_id1": [1, 0, 1, 1, -1],
+                "user_id2": [0, 0, 0, 0, 0],
+            }
+        },
+    }
+    user_ids = ["user_id1", "user_id2"]
+    kappa_matrix = _compute_kappa_matrix(
+        kappa_stats_raw_data=raw_data
+    )
+    assert (len(kappa_matrix) == len(raw_data))
+    for label in kappa_matrix:
+        matrix_per_label = kappa_matrix[label]
+        assert (len(matrix_per_label) == len(user_ids))
+        for user in matrix_per_label:
+            assert (len(matrix_per_label[user]) == len(user_ids))
+            for user_id in user_ids:
+                if user == user_id:
+                    assert (matrix_per_label[user][user_id] == 1)
+                else:
+                    assert math.isnan(matrix_per_label[user][user_id])
+
+
+
+@pytest.mark.parametrize("task_id,user_ids,annotations_per_user,"
+                         "results_lookup,expected",
                          [
                              ("FakeId", ["User1"], {"User1": ["anno1",
-                                                              "anno2"]},
+                                                              "anno2"]}, {},
                               ["There is only one user User1"]),
-                             ("FakeId", ["User1", "User2"], {},
+                             ("FakeId", ["User1", "User2"], {}, {},
                               ["There are no annotations from any user yet."]),
                          ]
                          )
 def test__calculate_per_label_kappa_stats_table_edge_cases(task_id, user_ids,
                                                           annotations_per_user,
+                                                          results_lookup,
                                                           expected):
     kappa_matrix_html_tables = _calculate_per_label_kappa_stats_table(
         task_id,
         user_ids,
-        annotations_per_user
+        annotations_per_user,
+        results_lookup
     )
 
     assert kappa_matrix_html_tables == expected

--- a/tests/unit/test_export_labeled_examples.py
+++ b/tests/unit/test_export_labeled_examples.py
@@ -1,4 +1,4 @@
-from ar.data import _export_labeled_examples
+from ar.data import _export_distinct_labeled_examples
 
 
 def test__export_labeled_examples__simple():
@@ -56,7 +56,7 @@ def test__export_labeled_examples__simple():
         },
     ]
 
-    result = _export_labeled_examples(sample_annotations)
+    result = _export_distinct_labeled_examples(sample_annotations)
     assert result == [
         {'text': 'sometext_1', 'labels': {'HEALTHCARE': 1, 'POP_HEALTH': -1}},
         {'text': 'sometext_2', 'labels': {'HEALTHCARE': -1}}
@@ -95,7 +95,7 @@ def test__export_labeled_examples__empty_text():
         },
     ]
 
-    result = _export_labeled_examples(sample_annotations)
+    result = _export_distinct_labeled_examples(sample_annotations)
 
     # Note the behaviour for missing text is not ideal, but this is the
     # 'official' behaviour for now.


### PR DESCRIPTION
Rewrite the kappa matrix calculation. The unit test is tricky. I was using a `set.intersection` in the code, which created an unstable output that failed the test intermittently...

For users who have no overlap on the annotation, the output is nan by default. Let me know if we want a prettier display.

![image](https://user-images.githubusercontent.com/45179326/78940006-264b6080-7a83-11ea-9641-135b1de345a2.png)
