### PR TITLE
Migration script from loading the file to the db tables

### DIFF
--- a/ar/__init__.py
+++ b/ar/__init__.py
@@ -10,7 +10,7 @@ from inference.base import ITextCatModel
 from inference import get_predicted
 from inference.random_model import RandomModel
 
-from .data import fetch_all_annotation_ids
+from .data import fetch_all_ar_ids
 from .utils import get_ar_id, timeit
 
 Pred = namedtuple('Pred', ['score', 'fname', 'line_number'])
@@ -139,7 +139,7 @@ def generate_annotation_requests(task_id: str,
 
 def _build_blacklist_fn(task: Task):
     _lookup = {
-        user: set(fetch_all_annotation_ids(task.task_id, user))
+        user: set(fetch_all_ar_ids(task.task_id, user))
         for user in task.annotators
     }
 

--- a/ar/data.py
+++ b/ar/data.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import shutil
 import itertools
@@ -20,27 +21,56 @@ from db import _task_dir
 ###############################################################################
 # I chose to write it all on disk for now - we can change it to a db later.
 
+def get_or_create(db_session, model, exclude_keys_in_retrieve=None, **kwargs):
+    """Retrieve an instance from the database based on key and value
+    specified in kwargs but excluding those in the exclude_keys_in_retrieve.
+
+    :param db_session: database session
+    :param model: The db model class name
+    :param exclude_keys_in_retrieve: keys to exclude in retrieve
+    :param kwargs: key-value pairs to retrieve or create an instance
+    :return: a model instance
+    """
+    if exclude_keys_in_retrieve is None:
+        exclude_keys_in_retrieve = []
+    read_kwargs = copy.copy(kwargs)
+    for key in exclude_keys_in_retrieve:
+        read_kwargs.pop(key, None)
+
+    instance = db_session.query(model).filter_by(**read_kwargs).one_or_none()
+    if instance:
+        return instance
+    else:
+        instance = model(**kwargs)
+        db_session.add(instance)
+        db_session.commit()
+        logging.info("Created a new instance of {}".format(instance))
+        return instance
+
 
 def fetch_labels_by_entity_type(entity_type_name):
+    """Fetch all labels for an entity type.
+
+    :param entity_type_name: the entity type name
+    :return: all the labels under the entity type
+    """
     labels = Label.query.join(EntityType).filter(EntityType.name ==
                                                  entity_type_name).all()
     return [label.name for label in labels]
 
 
 def save_labels_by_entity_type(entity_type_name, labels):
+    """Update labels under the entity type.
+
+    If entity type doesn't exist, create it first.
+
+    :param entity_type_name: the entity type name
+    :param labels: labels to be saved
+    """
     logging.info("Finding the EntityType for {}".format(entity_type_name))
-    entity_type_id = db.session.query(EntityType.id).filter_by(
-        name=entity_type_name).scalar()
-    if entity_type_id is None:
-        entity_type = EntityType(name=entity_type_name)
-        db.session.add(entity_type)
-        db.session.commit()
-        entity_type_id = entity_type.id
-        logging.info("Created a new EntityType {} with id {}".format(
-            entity_type_name, entity_type_id
-        ))
+    entity_type = get_or_create(db.session, EntityType, name=entity_type_name)
     for label_name in labels:
-        label = Label(name=label_name, entity_type_id=entity_type_id)
+        label = Label(name=label_name, entity_type_id=entity_type.id)
         db.session.add(label)
     db.session.commit()
 
@@ -196,7 +226,6 @@ def fetch_all_ar_ids(task_id, user_id):
     Return a list of ar_id for this task that has been annotated by this user.
     '''
     _dir = os.path.join(_task_dir(task_id), DIR_ANNO, user_id)
-    print(_dir)
     return _get_all_ar_ids_in_dir(_dir)
 
 

--- a/ar/data.py
+++ b/ar/data.py
@@ -133,7 +133,7 @@ def get_next_ar(task_id, user_id, ar_id):
         - If nothing left to label, return None
     '''
     ar_all = fetch_all_ar(task_id, user_id)
-    ar_done = set(fetch_all_annotation_ids(task_id, user_id))
+    ar_done = set(fetch_all_ar_ids(task_id, user_id))
 
     try:
         idx = ar_all.index(ar_id)
@@ -191,11 +191,12 @@ def fetch_annotation(task_id, user_id, ar_id):
         return None
 
 
-def fetch_all_annotation_ids(task_id, user_id):
+def fetch_all_ar_ids(task_id, user_id):
     '''
     Return a list of ar_id for this task that has been annotated by this user.
     '''
     _dir = os.path.join(_task_dir(task_id), DIR_ANNO, user_id)
+    print(_dir)
     return _get_all_ar_ids_in_dir(_dir)
 
 
@@ -251,7 +252,7 @@ def compute_annotation_statistics(task_id):
     results_per_task_user_anno_id = dict()
 
     for user_id in user_ids:
-        anno_ids = fetch_all_annotation_ids(task_id, user_id)
+        anno_ids = fetch_all_ar_ids(task_id, user_id)
         anno_ids_per_user[user_id] = set(anno_ids)
         n_annotations_per_user[user_id] = len(anno_ids)
 
@@ -595,7 +596,7 @@ def _export_distinct_labeled_examples(annotations_iterator):
 def _gather_distinct_labeled_examples(task_id):
     def annotations_iterator():
         for user_id in _get_all_annotators_from_annotated(task_id):
-            for ar_id in fetch_all_annotation_ids(task_id, user_id):
+            for ar_id in fetch_all_ar_ids(task_id, user_id):
                 anno = fetch_annotation(task_id, user_id, ar_id)
 
                 yield anno

--- a/bin/migrate_json_to_db.py
+++ b/bin/migrate_json_to_db.py
@@ -1,0 +1,85 @@
+import copy
+import hashlib
+import json
+import sys
+from os import environ
+
+sys.path.append(".")
+
+from ar import fetch_all_ar_ids
+from ar.data import fetch_annotation, _get_all_annotators_from_annotated
+from db.config import DevelopmentConfig
+from db.model import Database, User, EntityType, Context, Entity, Label, \
+    ClassificationAnnotation
+
+ENTITY_TYPE_NAME = "company"
+db = Database(DevelopmentConfig.SQLALCHEMY_DATABASE_URI)
+
+
+def convert_annotation_result_in_batch(task_id, username):
+    annotation_request_ids = fetch_all_ar_ids(task_id, username)
+    for ar_id in annotation_request_ids:
+        anno = fetch_annotation(task_id, username, ar_id)
+        _convert_single_annotation(anno, username)
+        print("Converted annotation with ar_id {}".format(ar_id))
+
+
+def _convert_single_annotation(anno, username):
+    user = get_or_create(User, username=username)
+
+    entity_type = get_or_create(EntityType, name=ENTITY_TYPE_NAME)
+
+    annotation_context = json.dumps(anno["req"]["data"], sort_keys=True)
+    context = get_or_create(Context, exclude_keys_in_read=["data"],
+                            hash=hashlib.md5(
+                                annotation_context.encode()).hexdigest(),
+                            data=annotation_context)
+
+    company_name = anno["req"]["data"]["meta"]["name"]
+    company_name = company_name if company_name is not None else "unknown"
+    domain = anno["req"]["data"]["meta"].get("domain", company_name)
+    domain = domain if domain is not None else company_name
+    entity = get_or_create(Entity, name=domain,
+                           entity_type_id=entity_type.id)
+
+    for label_name, label_value in anno["anno"]["labels"].items():
+        label = get_or_create(Label, name=label_name,
+                              entity_type_id=entity_type.id)
+
+        _ = get_or_create(ClassificationAnnotation,
+                          value=label_value,
+                          entity_id=entity.id,
+                          label_id=label.id,
+                          user_id=user.id,
+                          context_id=context.id)
+
+
+def get_or_create(model, exclude_keys_in_read=None, **kwargs):
+    if exclude_keys_in_read is None:
+        exclude_keys_in_read = []
+    read_kwargs = copy.copy(kwargs)
+    for key in exclude_keys_in_read:
+        read_kwargs.pop(key, None)
+
+    instance = db.session.query(model).filter_by(**read_kwargs).one_or_none()
+    if instance:
+        return instance
+    else:
+        instance = model(**kwargs)
+        db.session.add(instance)
+        db.session.commit()
+        print("Created a new instance of {}".format(instance))
+        return instance
+
+
+if __name__ == "__main__":
+    environ['ANNOTATION_TOOL_TASKS_DIR'] = "/annotation_tool/__tasks"
+
+    task_ids = ["8a79a035-56fa-415c-8202-9297652dfe75"]
+    for task_id in task_ids:
+        usernames = _get_all_annotators_from_annotated(task_id)
+        for username in usernames:
+            convert_annotation_result_in_batch(
+                task_id=task_id,
+                username=username,
+            )

--- a/db/model.py
+++ b/db/model.py
@@ -147,6 +147,10 @@ class JobStatus:
     INIT = "init"
 
 
+class EntityTypeEnum:
+    COMPANY = "company"
+
+
 class BackgroundJob(Base):
     __tablename__ = 'background_job'
 

--- a/db/model.py
+++ b/db/model.py
@@ -134,7 +134,7 @@ class ClassificationAnnotation(Base):
             self.context_id,
             self.value,
             self.created_at,
-            self.last_updated_at
+            self.updated_at
         )
 
 

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -1,5 +1,5 @@
 from ar.data import (
-    fetch_all_ar, fetch_ar, fetch_annotation, fetch_all_annotation_ids, get_next_ar,
+    fetch_all_ar, fetch_ar, fetch_annotation, fetch_all_ar_ids, get_next_ar,
     build_empty_annotation, annotate_ar
 )
 import json
@@ -38,7 +38,7 @@ def show(id):
 
     task = Task.fetch(id)
     ars = fetch_all_ar(id, user_id)
-    annotated = set(fetch_all_annotation_ids(id, user_id))
+    annotated = set(fetch_all_ar_ids(id, user_id))
     has_annotation = [x in annotated for x in ars]
 
     et = time.time()

--- a/shared/config.py
+++ b/shared/config.py
@@ -8,30 +8,35 @@ class Config:
 
     This module is designed to fail loudly when a required env var is not found.
     """
-
-    def get_backend_password():
+    @classmethod
+    def get_backend_password(cls):
         return environ['ANNOTATION_TOOL_BACKEND_PASSWORD']
 
-    def get_frontend_secret():
+    @classmethod
+    def get_frontend_secret(cls):
         return environ['ANNOTATION_TOOL_FRONTEND_SECRET']
 
-    def get_frontend_server():
+    @classmethod
+    def get_frontend_server(cls):
         '''e.g. http://localhost:5001'''
         return environ['ANNOTATION_TOOL_FRONTEND_SERVER']
 
-    def get_tasks_dir():
+    @classmethod
+    def get_tasks_dir(cls):
         d = environ.get('ANNOTATION_TOOL_TASKS_DIR')
         if d is None:
             d = os.path.join(os.getcwd(), '__tasks')
         return d
 
-    def get_data_dir():
+    @classmethod
+    def get_data_dir(cls):
         d = environ.get('ANNOTATION_TOOL_DATA_DIR')
         if d is None:
             d = os.path.join(os.getcwd(), '__data')
         return d
 
-    def get_inference_cache_dir():
+    @classmethod
+    def get_inference_cache_dir(cls):
         d = environ.get('ANNOTATION_TOOL_INFERENCE_CACHE_DIR')
         if d is None:
             d = os.path.join(os.getcwd(), '__infcache')

--- a/shared/config.py
+++ b/shared/config.py
@@ -8,35 +8,35 @@ class Config:
 
     This module is designed to fail loudly when a required env var is not found.
     """
-    @classmethod
-    def get_backend_password(cls):
+    @staticmethod
+    def get_backend_password():
         return environ['ANNOTATION_TOOL_BACKEND_PASSWORD']
 
-    @classmethod
-    def get_frontend_secret(cls):
+    @staticmethod
+    def get_frontend_secret():
         return environ['ANNOTATION_TOOL_FRONTEND_SECRET']
 
-    @classmethod
-    def get_frontend_server(cls):
+    @staticmethod
+    def get_frontend_server():
         '''e.g. http://localhost:5001'''
         return environ['ANNOTATION_TOOL_FRONTEND_SERVER']
 
-    @classmethod
-    def get_tasks_dir(cls):
+    @staticmethod
+    def get_tasks_dir():
         d = environ.get('ANNOTATION_TOOL_TASKS_DIR')
         if d is None:
             d = os.path.join(os.getcwd(), '__tasks')
         return d
 
-    @classmethod
-    def get_data_dir(cls):
+    @staticmethod
+    def get_data_dir():
         d = environ.get('ANNOTATION_TOOL_DATA_DIR')
         if d is None:
             d = os.path.join(os.getcwd(), '__data')
         return d
 
-    @classmethod
-    def get_inference_cache_dir(cls):
+    @staticmethod
+    def get_inference_cache_dir():
         d = environ.get('ANNOTATION_TOOL_INFERENCE_CACHE_DIR')
         if d is None:
             d = os.path.join(os.getcwd(), '__infcache')

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import pandas as pd
 import json
@@ -67,3 +68,12 @@ def stem(fname):
     """/blah/my_file.json.gz --> my_file"""
     stem = Path(fname).stem
     return stem[:stem.index('.')] if '.' in stem else stem
+
+
+def generate_md5_hash(data: str):
+    """Generate a md5 hash of the input str
+
+    :param data: the input str
+    :return: the md5 hash string
+    """
+    return hashlib.md5(data.encode()).hexdigest()

--- a/tests/integration/test_ar_flow.py
+++ b/tests/integration/test_ar_flow.py
@@ -6,7 +6,7 @@ from ar.data import (
     fetch_tasks_for_user,
     fetch_all_ar,
     fetch_ar,
-    fetch_all_annotation_ids,
+    fetch_all_ar_ids,
     fetch_annotation,
     annotate_ar,
     get_next_ar,
@@ -93,7 +93,7 @@ class TestARFlow:
         assert annotation_requests[2]['ar_id'] == all_ars[2]
 
         # User has not labeled anything yet.
-        assert len(fetch_all_annotation_ids(task_id, user_id)) == 0
+        assert len(fetch_all_ar_ids(task_id, user_id)) == 0
 
         ar_detail = fetch_ar(task_id, user_id, all_ars[0])
         assert ar_detail['ar_id'] == annotation_requests[0]['ar_id']
@@ -104,20 +104,20 @@ class TestARFlow:
         annotate_ar(task_id, user_id, all_ars[0], my_anno)
         assert fetch_annotation(task_id, user_id, all_ars[0])[
             'anno'] == my_anno
-        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
+        assert len(fetch_all_ar_ids(task_id, user_id)) == 1
 
         # Annotate the same thing again updates the annotation
         updated_anno = {'labels': {'FINTECH': 1, 'HEALTHCARE': 0}}
         annotate_ar(task_id, user_id, all_ars[0], updated_anno)
         assert fetch_annotation(task_id, user_id, all_ars[0])[
             'anno'] == updated_anno
-        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
+        assert len(fetch_all_ar_ids(task_id, user_id)) == 1
 
         # Annotate something that doesn't exist
         # (this might happen when master is updating - we'll try to avoid it)
         annotate_ar(task_id, user_id, 'doesnotexist',
                     {'labels': {'HEALTHCARE': 1}})
-        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
+        assert len(fetch_all_ar_ids(task_id, user_id)) == 1
 
         # Fetch next thing to be annotated
         # ar[0] is labeled, label ar[1]
@@ -170,7 +170,7 @@ class TestARFlow:
             fetch_all_ar(task_id, user_id))
 
         # Check existing annotations still exist
-        assert len(fetch_all_annotation_ids(task_id, user_id)) == 1
+        assert len(fetch_all_ar_ids(task_id, user_id)) == 1
 
         # Annotate something thing in the new batch
         my_anno = {'labels': {'MACHINELEARNING': 0,
@@ -179,7 +179,7 @@ class TestARFlow:
         annotate_ar(task_id, user_id, all_ars[0], my_anno)
         assert fetch_annotation(task_id, user_id, all_ars[0])[
             'anno'] == my_anno
-        assert len(fetch_all_annotation_ids(task_id, user_id)) == 2
+        assert len(fetch_all_ar_ids(task_id, user_id)) == 2
 
         # TODO: Write the test. When there is 1 thing left in queue, get_next_ar should return None.
         # assert get_next_ar(task_id, user_id, all_ars[-1]) == None

--- a/tests/integration/test_train_flow.py
+++ b/tests/integration/test_train_flow.py
@@ -4,7 +4,7 @@ from db.task import Task
 from ar.data import (
     save_new_ar_for_user,
     annotate_ar,
-    fetch_all_annotation_ids
+    fetch_all_ar_ids
 )
 from ar.utils import get_ar_id
 from train.prep import (
@@ -86,7 +86,7 @@ class TestTrainFlow:
 
     def test__test_setup_is_ok(self):
         task = self.task
-        assert len(fetch_all_annotation_ids(task.task_id, 'eddie_test')) == 20
+        assert len(fetch_all_ar_ids(task.task_id, 'eddie_test')) == 20
 
     def test__train_flow(self, tmpdir):
         task = self.task


### PR DESCRIPTION
Script for loading the file to the db tables. Please run the script under the project root instead of the bin folder like `python bin/migrate_json_to_db.py` but make sure you edit the script to specify the task ids. Thought this could be more flexible than fully automate loading the whole `__task` folder.

There is something missing in the python library path but it seems that we need to do some bigger renaming and folder moving changes to fix it. Since this is a one-time thing (I hope), I'm just hard-coding the path. 

----Update----
Run with `python -m scripts.migrate_json_to_db` under the project root folder.