### PR TITLE
Refactor code for Label and EntityType

### DIFF
--- a/db/model.py
+++ b/db/model.py
@@ -1,3 +1,5 @@
+import logging
+import copy
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.schema import ForeignKey, Column
@@ -281,3 +283,61 @@ class AnnotationRequest(Base):
 
     # Where this request came from. e.g. {'source': BackgroundJob, 'id': 123}
     source = Column(JSON)
+
+
+# =============================================================================
+# Convenience Functions
+
+
+def get_or_create(db_session, model, exclude_keys_in_retrieve=None, **kwargs):
+    """Retrieve an instance from the database based on key and value
+    specified in kwargs but excluding those in the exclude_keys_in_retrieve.
+
+    :param db_session: database session
+    :param model: The db model class name
+    :param exclude_keys_in_retrieve: keys to exclude in retrieve
+    :param kwargs: key-value pairs to retrieve or create an instance
+    :return: a model instance
+    """
+    if exclude_keys_in_retrieve is None:
+        exclude_keys_in_retrieve = []
+    read_kwargs = copy.copy(kwargs)
+    for key in exclude_keys_in_retrieve:
+        read_kwargs.pop(key, None)
+
+    instance = db_session.query(model).filter_by(**read_kwargs).one_or_none()
+    if instance:
+        return instance
+    else:
+        instance = model(**kwargs)
+        db_session.add(instance)
+        db_session.commit()
+        logging.info("Created a new instance of {}".format(instance))
+        return instance
+
+
+def fetch_labels_by_entity_type(dbsession, entity_type_name):
+    """Fetch all labels for an entity type.
+
+    :param entity_type_name: the entity type name
+    :return: all the labels under the entity type
+    """
+    labels = dbsession.query(Label).join(EntityType) \
+        .filter(EntityType.name == entity_type_name).all()
+    return [label.name for label in labels]
+
+
+def save_labels_by_entity_type(dbsession, entity_type_name, label_names):
+    """Update labels under the entity type.
+
+    If entity type doesn't exist, create it first.
+
+    :param entity_type_name: the entity type name
+    :param label_names: labels to be saved
+    """
+    logging.info("Finding the EntityType for {}".format(entity_type_name))
+    entity_type = get_or_create(dbsession, EntityType, name=entity_type_name)
+    labels = [Label(name=name, entity_type_id=entity_type.id)
+              for name in label_names]
+    dbsession.add_all(labels)
+    dbsession.commit()

--- a/frontend/labels.py
+++ b/frontend/labels.py
@@ -1,7 +1,7 @@
 import logging
 
-from ar.data import (
-    fetch_labels_by_entity_type, save_labels_by_entity_type)
+from db.model import (
+    db, fetch_labels_by_entity_type, save_labels_by_entity_type)
 import json
 from flask import (
     Blueprint, request, jsonify, Response)
@@ -15,7 +15,7 @@ bp = Blueprint('labels', __name__, url_prefix='/labels')
 # @login_required
 def fetch_all_labels():
     entity = request.args["entity_type"]
-    labels = fetch_labels_by_entity_type(entity)
+    labels = fetch_labels_by_entity_type(db.session, entity)
     return jsonify(labels)
 
 
@@ -25,14 +25,15 @@ def save_labels():
     data = json.loads(request.data)
     entity_type_name = data['entity_type']
     new_labels = set(data['labels'])
-    labels = set(fetch_labels_by_entity_type(entity_type_name))
+    labels = set(fetch_labels_by_entity_type(db.session, entity_type_name))
     logging.error("Existing labels: {}".format(labels))
     new_labels = new_labels.difference(labels)
     try:
         logging.error("Updating new labels {} for EntityType {}".format(
             str(new_labels), entity_type_name
         ))
-        save_labels_by_entity_type(entity_type_name, list(new_labels))
+        save_labels_by_entity_type(
+            db.session, entity_type_name, list(new_labels))
         msg = "Labels for entity {} have been updated".format(entity_type_name)
         return Response(msg, status=200, mimetype='application/json')
     except Exception as e:

--- a/tests/unit/test_frontend_model.py
+++ b/tests/unit/test_frontend_model.py
@@ -1,6 +1,8 @@
 import frontend
-from ar.data import fetch_labels_by_entity_type, save_labels_by_entity_type
-from db.model import db, Label, EntityType
+from db.model import (
+    db, Label, EntityType,
+    fetch_labels_by_entity_type, save_labels_by_entity_type
+)
 from db.config import TestingConfig
 from flask_testing import TestCase
 
@@ -31,21 +33,21 @@ class FrontEndModelTest(TestCase):
         db.session.commit()
 
     def test_fetch_labels_by_entity_type(self):
-        labels = fetch_labels_by_entity_type(entity_type_name="company")
+        labels = fetch_labels_by_entity_type(db.session, "company")
         for label in test_labels:
             assert label in labels
 
     def test_fetch_labels_for_unknown_entity_type(self):
-        labels = fetch_labels_by_entity_type(entity_type_name="unknown")
+        labels = fetch_labels_by_entity_type(db.session, "unknown")
         assert len(labels) == 0
 
     def test_save_labels_for_existing_entity_type(self):
         new_labels = ["logstic"]
         entity_type_name = "company"
-        save_labels_by_entity_type(entity_type_name, new_labels)
+        save_labels_by_entity_type(db.session, entity_type_name, new_labels)
 
         exisiting_labels = fetch_labels_by_entity_type(
-            entity_type_name="company")
+            db.session, "company")
 
         expected_label_set = set(test_labels)
         expected_label_set.update(new_labels)
@@ -55,10 +57,10 @@ class FrontEndModelTest(TestCase):
     def test_save_labels_for_new_entity_type(self):
         new_labels = ["startup", "x-googler"]
         entity_type_name = "people"
-        save_labels_by_entity_type(entity_type_name, new_labels)
+        save_labels_by_entity_type(db.session, entity_type_name, new_labels)
 
         exisiting_labels = fetch_labels_by_entity_type(
-            entity_type_name=entity_type_name)
+            db.session, entity_type_name)
 
         expected_label_set = set(new_labels)
 


### PR DESCRIPTION
1. Moved code about Label and EntityType from `ar/data` to `db/model`, because those classes are not specific to annotation requests.
2. I added a `dbsession` param to `fetch_labels_by_entity_type` and `save_labels_by_entity_type` so the user is forced to pass in a session. Doing so removes dependecy on Flask-Sqlalchemy at the expense of being more explicit.

I made the changes in the frontend tests. @JingJZ160 if you like, I can also remove the dependency on `flask_testing` for that test.