### PR TITLE
Add DataSnapshotJob

### DIFF
--- a/alembic/versions/4b41206a16ea_add_task_and_backgroundjob.py
+++ b/alembic/versions/4b41206a16ea_add_task_and_backgroundjob.py
@@ -32,7 +32,7 @@ def upgrade():
     op.create_table(
         'background_job',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('type', sa.Integer(), nullable=False),
+        sa.Column('type', sa.String(length=64), nullable=False),
         sa.Column('params', sa.JSON(), nullable=False),
         sa.Column('output', sa.JSON(), nullable=False),
         sa.Column('status', sa.String(length=64), nullable=False),

--- a/db/model.py
+++ b/db/model.py
@@ -195,7 +195,7 @@ class BackgroundJob(Base):
     __tablename__ = 'background_job'
 
     id = Column(Integer, primary_key=True)
-    type = Column(String, index=True, nullable=False)
+    type = Column(String(64), index=True, nullable=False)
     params = Column(JSON, nullable=False, default=lambda: {})
     output = Column(JSON, nullable=False, default=lambda: {})
     status = Column(String(64), nullable=False, default=JobStatus.Init)

--- a/scripts/migrate_json_to_db.py
+++ b/scripts/migrate_json_to_db.py
@@ -1,23 +1,62 @@
 import copy
 import hashlib
 import json
+import logging
 from os import environ
 
-from ar import fetch_all_ar_ids
-from ar.data import fetch_annotation, _get_all_annotators_from_annotated, \
-    get_or_create
+# Filesystem based data:
+from ar.data import (
+    # Requests
+    _get_all_annotators_from_requested,
+    fetch_all_ar,
+    fetch_ar,
+
+    # Annotations
+    _get_all_annotators_from_annotated,
+    fetch_all_ar_ids,
+    fetch_annotation,
+)
+from db.task import Task as _Task
+
 from db.config import DevelopmentConfig
-from db.model import Database, User, EntityType, Context, Entity, Label, \
-    ClassificationAnnotation, EntityTypeEnum
+from db.model import (
+    Database,
+
+    Label, EntityType, Entity, User, Context, ClassificationAnnotation,
+    BackgroundJob, Task, AnnotationRequest,
+
+    AnnotationRequestStatus, AnnotationType, JobType, JobStatus,
+    EntityTypeEnum,
+
+    get_or_create
+)
 from shared.utils import generate_md5_hash
 
-ENTITY_TYPE_NAME = EntityTypeEnum.COMPANY
+
 db = Database(DevelopmentConfig.SQLALCHEMY_DATABASE_URI)
 
 
+def _get_or_create_company_entity(company_name, domain):
+    entity_type = get_or_create(
+        db.session, EntityType, name=EntityTypeEnum.COMPANY)
+    company_name = company_name if company_name is not None else "unknown"
+    domain = domain if domain is not None else company_name
+    entity = get_or_create(db.session, Entity, name=domain,
+                           entity_type_id=entity_type.id)
+    return entity_type, entity
+
+
+def _get_or_create_anno_context(json_data):
+    annotation_context = json.dumps(json_data, sort_keys=True)
+    context = get_or_create(db.session, Context, exclude_keys_in_retrieve=["data"],
+                            hash=generate_md5_hash(annotation_context),
+                            data=annotation_context)
+    return context
+
+
 def convert_annotation_result_in_batch(task_id, username):
-    annotation_request_ids = fetch_all_ar_ids(task_id, username)
-    for ar_id in annotation_request_ids:
+    annotated_ar_ids = fetch_all_ar_ids(task_id, username)
+    for ar_id in annotated_ar_ids:
         anno = fetch_annotation(task_id, username, ar_id)
         _convert_single_annotation(anno, username)
         print("Converted annotation with ar_id {}".format(ar_id))
@@ -26,19 +65,11 @@ def convert_annotation_result_in_batch(task_id, username):
 def _convert_single_annotation(anno, username):
     user = get_or_create(db.session, User, username=username)
 
-    entity_type = get_or_create(db.session, EntityType, name=ENTITY_TYPE_NAME)
-
-    annotation_context = json.dumps(anno["req"]["data"], sort_keys=True)
-    context = get_or_create(db.session, Context, exclude_keys_in_retrieve=["data"],
-                            hash=generate_md5_hash(annotation_context),
-                            data=annotation_context)
-
     company_name = anno["req"]["data"]["meta"]["name"]
-    company_name = company_name if company_name is not None else "unknown"
     domain = anno["req"]["data"]["meta"].get("domain", company_name)
-    domain = domain if domain is not None else company_name
-    entity = get_or_create(db.session, Entity, name=domain,
-                           entity_type_id=entity_type.id)
+    entity_type, entity = _get_or_create_company_entity(company_name, domain)
+
+    context = _get_or_create_anno_context(anno["req"]["data"])
 
     for label_name, label_value in anno["anno"]["labels"].items():
         label = get_or_create(db.session, Label, name=label_name,
@@ -52,14 +83,112 @@ def _convert_single_annotation(anno, username):
                           context_id=context.id)
 
 
-if __name__ == "__main__":
-    environ['ANNOTATION_TOOL_TASKS_DIR'] = "/annotation_tool/__tasks"
+def convert_annotation_request_in_batch(task_id, username):
+    requested_ar_ids = fetch_all_ar(task_id, username)
+    for idx, ar_id in enumerate(requested_ar_ids):
+        req = fetch_ar(task_id, username, ar_id)
+        _convert_single_request(req, username, task_id, order=idx)
+        print("Converted request with ar_id {}".format(ar_id))
 
+
+def _convert_single_request(req, username, task_id, order):
+    user = get_or_create(db.session, User, username=username)
+
+    '''
+    Example:
+    {
+        "ar_id": "0c4a398f9d3ab6bae0dd40f8ce7092720131c08e516466f02231a3d3",
+        "fname": "/Users/blah/myfile.jsonl",
+        "line_number": 161,
+        "score": 0.3397799678402079,
+        "data": {
+            "text": "Provider of an online learning pl...",
+            "meta": {
+                "name": "ACME",
+                "domain": "acme.com"
+            }
+        }
+    }
+    '''
+    company_name = req["data"]["meta"]["name"]
+    domain = req["data"]["meta"].get("domain", company_name)
+    entity_type, entity = _get_or_create_company_entity(company_name, domain)
+
+    context = _get_or_create_anno_context(req["data"])
+
+    get_or_create(
+        db.session, AnnotationRequest,
+        user_id=user.id,
+        context_id=context.id,
+        annotation_type=AnnotationType.ClassificationAnnotation,
+        status=AnnotationRequestStatus.Pending,
+        task_id=task_id,
+        order=order,
+        name=req['ar_id'],
+        additional_info={
+            'ar_id': req['ar_id'],
+            'fname': req['fname'],
+            'line_number': req['line_number'],
+            'score': req['score']
+        },
+        source={
+            'source': 'db-migration'
+        },
+        exclude_keys_in_retrieve=['additional_info', 'source']
+    )
+
+
+def convert_task(task_id):
+    _task = _Task.fetch(task_id)
+    # Although names are not forced to be unique, I doubt any existing use case
+    # has a duplicate name.
+    return get_or_create(
+        db.session, Task,
+        name=_task.name, default_params=_task.to_json(),
+        exclude_keys_in_retrieve=['default_params']
+    )
+
+
+if __name__ == "__main__":
+    logging.root.setLevel(logging.INFO)
+    logging.info(f"Migrate json to db")
+
+    import argparse
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('--tasks_dir', default="/annotation_tool/__tasks")
+    args = parser.parse_args()
+
+    tasks_dir = args.tasks_dir
+
+    logging.info(f"Tasks dir: {tasks_dir}")
+    environ['ANNOTATION_TOOL_TASKS_DIR'] = tasks_dir
+
+    # # Uncomment to drop database and restart from scratch.
+    # from db.model import Base
+    # Base.metadata.drop_all(db.engine)
+    # Base.metadata.create_all(db.engine)
+
+    # TODO run this on all tasks.
     task_ids = ["8a79a035-56fa-415c-8202-9297652dfe75"]
     for task_id in task_ids:
+        task = convert_task(task_id)
+
+        usernames = _get_all_annotators_from_requested(task_id)
+        for username in usernames:
+            convert_annotation_request_in_batch(
+                task_id=task_id,
+                username=username
+            )
+
         usernames = _get_all_annotators_from_annotated(task_id)
         for username in usernames:
             convert_annotation_result_in_batch(
                 task_id=task_id,
                 username=username,
             )
+
+    print("--Counts--")
+    tables = [Label, EntityType, Entity, User, Context,
+              ClassificationAnnotation, BackgroundJob, Task, AnnotationRequest]
+    for t in tables:
+        print(t, db.session.query(t).count())

--- a/scripts/migrate_json_to_db.py
+++ b/scripts/migrate_json_to_db.py
@@ -25,8 +25,7 @@ from db.model import (
     Label, EntityType, Entity, User, Context, ClassificationAnnotation,
     BackgroundJob, Task, AnnotationRequest,
 
-    AnnotationRequestStatus, AnnotationType, JobType, JobStatus,
-    EntityTypeEnum,
+    AnnotationRequestStatus, AnnotationType, JobStatus, EntityTypeEnum,
 
     get_or_create
 )
@@ -169,6 +168,7 @@ if __name__ == "__main__":
     # Base.metadata.create_all(db.engine)
 
     # TODO run this on all tasks.
+    # TODO migrate over the ML models
     task_ids = ["8a79a035-56fa-415c-8202-9297652dfe75"]
     for task_id in task_ids:
         task = convert_task(task_id)

--- a/tests/unit/test_annotation_request_model.py
+++ b/tests/unit/test_annotation_request_model.py
@@ -1,14 +1,12 @@
 from tests.sqlalchemy_conftest import *
 from db.model import (
-    AnnotationRequest, BackgroundJob, JobType, JobStatus,
+    AnnotationRequest, AnnotationRequestJob, JobStatus,
     User, Context, Task, AnnotationType
 )
 
 
 def _populate_db(dbsession):
-    job = BackgroundJob(
-        type=JobType.AnnotationRequestGenerator,
-        params={}, output={}, status=JobStatus.INIT)
+    job = AnnotationRequestJob()
     dbsession.add(job)
 
     user = User(username="foo")
@@ -24,7 +22,7 @@ def test_sanity(dbsession):
 
 def test_create_annotation_request(dbsession):
     _populate_db(dbsession)
-    job = dbsession.query(BackgroundJob).first()
+    job = dbsession.query(AnnotationRequestJob).first()
     user = dbsession.query(User).first()
 
     context = Context(
@@ -42,7 +40,7 @@ def test_create_annotation_request(dbsession):
         order=12,
         name="Testing",
         additional_info={'domain': 'www.google.com'},
-        source={'type': 'BackgroundJob', 'id': job.id}
+        source={'type': 'AnnotationRequestJob', 'id': job.id}
     )
     dbsession.add(req)
     dbsession.commit()

--- a/tests/unit/test_data_snapshot_job.py
+++ b/tests/unit/test_data_snapshot_job.py
@@ -1,0 +1,48 @@
+from tests.sqlalchemy_conftest import *
+from db.model import DataSnapshotJob, JobStatus
+
+
+def _populate_db(dbsession):
+    invalid_job = DataSnapshotJob()
+    dbsession.add(invalid_job)
+
+    valid_job = DataSnapshotJob.create('positive', now=1)
+    dbsession.add(valid_job)
+
+    dbsession.commit()
+
+    return [invalid_job, valid_job]
+
+
+def test_sanity(dbsession):
+    invalid_job, valid_job = _populate_db(dbsession)
+
+    assert invalid_job.params == {}
+    assert invalid_job.get_output_fname() is None
+    assert valid_job.params != {}
+    assert valid_job.get_output_fname() == '1_positive.jsonl'
+
+
+def test_run(dbsession):
+    invalid_job, valid_job = _populate_db(dbsession)
+
+    def test_execute_fn(label_name, output_fname):
+        pass
+
+    invalid_job.run(execute_fn=test_execute_fn)
+    assert invalid_job.status == JobStatus.Failed
+    assert invalid_job.get_error() is not None
+
+    valid_job.run(execute_fn=test_execute_fn)
+    assert valid_job.status == JobStatus.Complete
+    assert valid_job.get_error() is None
+
+
+def test_bad_label_name(dbsession):
+    valid_job = DataSnapshotJob.create(
+        'this is a / dangerous . label /:=', now=123)
+    dbsession.add(valid_job)
+    dbsession.commit()
+
+    assert dbsession.query(DataSnapshotJob).first().get_output_fname() == \
+        '123_this_is_a_dangerous_._label.jsonl'


### PR DESCRIPTION
Using [Single Table Inheritance](https://docs.sqlalchemy.org/en/13/orm/inheritance.html#single-table-inheritance) I created `DataSnapshotJob`, `AnnotationRequestJob`,  `TextClassificationModelTrainingJob`, and `TextClassificationModelInferenceJob` as children of `BackgroundJob`.

This is nice because we don't have to manage job types manually and still enjoy the benefits of having a single table & shared behaviour.

I implemented the behaviour of `DataSnapshotJob` here, the other tables will follow in future PRs.

-- Edit --
I needed to fix the Alembic migration, change the `BackgroundJob:type` field from an Integer to a String. Please delete the local db and run migration again.