### PR TITLE
Changes made to wire up with the UI of the backend server

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -4,6 +4,8 @@ from flask import (
     Flask, redirect, url_for
 )
 
+from db.config import DevelopmentConfig
+from db.model import db
 from .auth import auth
 
 
@@ -12,15 +14,14 @@ def create_app(test_config=None):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_mapping(
         SECRET_KEY='athena_todo_change_this_in_prod',
-        DATABASE=os.path.join(app.instance_path, 'athena.sqlite'),
     )
 
     if test_config is None:
         # load the instance config, if it exists, when not testing
-        app.config.from_pyfile('config.py', silent=True)
+        app.config.from_object(DevelopmentConfig)
     else:
         # load the test config if passed in
-        app.config.from_mapping(test_config)
+        app.config.from_object(test_config)
 
     # ensure the instance folder exists
     try:
@@ -28,6 +29,7 @@ def create_app(test_config=None):
     except OSError:
         pass
 
+    db.init_app(app)
     # -------------------------------------------------------------------------
     # Register custom Jinja Filters
 

--- a/backend/templates/tasks/show.html
+++ b/backend/templates/tasks/show.html
@@ -77,11 +77,48 @@
 </div>
 
 <div class="card my-2">
+    <div class="card-body">
+
+        <div class="row">
+          <div class="col-9">
+              <h4>
+                Annotation Requests
+              </h4>
+
+              <br />
+
+              <div class="row">
+                  <div class="col">
+                    <ul>
+                      <li>
+                        Total outstanding requests: {{annotation_request_statistics['total_outstanding_requests']}}
+                      </li>
+                      <li>
+                        Outstanding requests for each annotator:
+                        <ul>
+                          {% for k in annotation_request_statistics['n_outstanding_requests_per_user'] %}
+                          <li>
+                            {{k}}: {{annotation_request_statistics['n_outstanding_requests_per_user'][k]}}
+                          </li>
+                          {% endfor %}
+                        </ul>
+                      </li>
+                    </ul>
+                  </div>
+            </div>
+          </div>
+        </div>
+    </div>
+</div>
+
+
+<div class="card my-2">
   <div class="card-body">
+  {% for label in task.labels %}
     <div class="row">
       <div class="col-9">
         <h4>
-          Annotations
+          Annotations for {{label}}
         </h4>
 
         <br />
@@ -90,36 +127,17 @@
           <div class="col">
             <ul>
               <li>
-                Total outstanding requests: {{annotation_statistics['total_outstanding_requests']}}
+                Total Annotated: {{annotation_statistics_per_label[label]['total_annotations']}}
               </li>
               <li>
-                Outstanding requests for each annotator:
+                Total Distinct Annotated: {{annotation_statistics_per_label[label]['total_distinct_annotations']}}
+              </li>
+              <li>
+                Annotated result per value:
                 <ul>
-                  {% for k in annotation_statistics['n_outstanding_requests_per_user'] %}
                   <li>
-                    {{k}}: {{annotation_statistics['n_outstanding_requests_per_user'][k]}}
-                  </li>
-                  {% endfor %}
-                </ul>
-              </li>
-            </ul>
-          </div>
-          <div class="col">
-            <ul>
-              <li>
-                Total Annotated: {{annotation_statistics['total_annotations']}}
-              </li>
-              <li>
-                Total Distinct Annotated: {{annotation_statistics['total_distinct_annotations']}}
-              </li>
-              <li>
-                Annotated per label:
-                <ul>
-                  {% for k in annotation_statistics['n_annotations_per_label'] %}
-                  <li>
-                    {{k}}:
-                    {% for resp in annotation_statistics['n_annotations_per_label'][k] %}
-                    {% set n = annotation_statistics['n_annotations_per_label'][k][resp] %}
+                    {% for resp in annotation_statistics_per_label[label]['n_annotations_per_value'] %}
+                    {% set n = annotation_statistics_per_label[label]['n_annotations_per_value'][resp] %}
                     {% if resp == 1 %}
                     <span class='badge badge-pill badge-success'>{{resp}}</span>x{{n}}
                     {% elif resp == -1 %}
@@ -130,15 +148,14 @@
                     {% endfor %}
                   </li>
               </li>
-              {% endfor %}
             </ul>
             </li>
             <li>
               Annotated by each annotator:
               <ul>
-                {% for k in annotation_statistics['n_annotations_per_user'] %}
+                {% for k in annotation_statistics_per_label[label]['n_annotations_per_user'] %}
                 <li>
-                  {{k}}: {{annotation_statistics['n_annotations_per_user'][k]}}
+                  {{k}}: {{annotation_statistics_per_label[label]['n_annotations_per_user'][k]}}
                 </li>
                 {% endfor %}
               </ul>
@@ -149,12 +166,12 @@
 
         <div class="row">
           <div class="col">
-            <h6>Annotator Kappa Score Matrix Per Label</h6>
+            <h6>Annotator Kappa Score Matrix</h6>
             <div>
-              {% for k in annotation_statistics['kappa_table_per_label'] %}
+              {% for k in annotation_statistics_per_label[label]['kappa_table'] %}
               <div>
                 <b>{{k}}</b>
-                {{annotation_statistics['kappa_table_per_label'][k] | safe}}
+                {{annotation_statistics_per_label[label]['kappa_table'][k] | safe}}
               </div>
               {% endfor %}
             </div>
@@ -205,12 +222,14 @@
         {% endif %}
       </div>
     </div>
-
-
+  {% endfor %}
   </div>
 </div>
 
-{% if annotation_statistics['total_annotations'] > 0 or model_viewers | length > 0 %}
+{% for label in task.labels %}
+{% if annotation_statistics_per_label[label]['total_annotations'] > 0 or
+model_viewers |
+length > 0 %}
 
 <div class="card my-2">
   <div class="card-body">
@@ -301,6 +320,7 @@
 </div>
 
 {% endif %}
+{% endfor %}
 
 <script>
   //https://www.sanwebe.com/2014/04/select-all-text-in-element-on-click

--- a/backend/templates/tasks/show.html
+++ b/backend/templates/tasks/show.html
@@ -106,7 +106,48 @@
                     </ul>
                   </div>
             </div>
+
+            <div class="row">
+              <div class="col">
+                <h6>Annotator Login Links</h6>
+                <ul>
+                  {% for user, link in annotator_login_links %}
+                  <li>
+                    <b>{{user}}</b>: <span onclick="selectText(this.id)" id="{{link}}">{{link}}</span>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+
+
           </div>
+          <div class="col">
+        <div>
+          <form action="{{ url_for('tasks.assign', id=task.task_id) }}" method="POST">
+            <button type="submit" class="btn btn-sm btn-secondary">Request More Annotations</button>
+          </form>
+        </div>
+
+        <p>
+          <a href="{{ url_for('admin_view_ar_logs') }}" target="_blank">View Annotation Worker Logs</a>
+        </p>
+
+        {% if status_assign_jobs is defined and status_assign_jobs | length > 0 %}
+        <i class='small'>Refresh page to see updates</i>
+        <ul>
+          {% for status in status_assign_jobs %}
+          <li>
+            <h6>
+              <span class="badge badge-info">{{status}}</span>
+            </h6>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        No Recent Jobs
+        {% endif %}
+      </div>
         </div>
     </div>
 </div>
@@ -178,48 +219,9 @@
           </div>
         </div>
 
-        <div class="row">
-          <div class="col">
-            <h6>Annotator Login Links</h6>
-            <ul>
-              {% for user, link in annotator_login_links %}
-              <li>
-                <b>{{user}}</b>: <span onclick="selectText(this.id)" id="{{link}}">{{link}}</span>
-              </li>
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
-
         <!-- <code>
             {{annotation_statistics}}
           </code> -->
-      </div>
-      <div class="col">
-        <div>
-          <form action="{{ url_for('tasks.assign', id=task.task_id) }}" method="POST">
-            <button type="submit" class="btn btn-sm btn-secondary">Request More Annotations</button>
-          </form>
-        </div>
-
-        <p>
-          <a href="{{ url_for('admin_view_ar_logs') }}" target="_blank">View Annotation Worker Logs</a>
-        </p>
-
-        {% if status_assign_jobs is defined and status_assign_jobs | length > 0 %}
-        <i class='small'>Refresh page to see updates</i>
-        <ul>
-          {% for status in status_assign_jobs %}
-          <li>
-            <h6>
-              <span class="badge badge-info">{{status}}</span>
-            </h6>
-          </li>
-          {% endfor %}
-        </ul>
-        {% else %}
-        No Recent Jobs
-        {% endif %}
       </div>
     </div>
   {% endfor %}

--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -21,8 +21,6 @@ def create_app(test_config=None):
         SECRET_KEY='athena_todo_change_this_in_prod',
     )
 
-    logging.error(DevelopmentConfig.SQLALCHEMY_DATABASE_URI)
-
     if test_config is None:
         # load the instance config, if it exists, when not testing
         # app.config.from_pyfile('config.py', silent=True)
@@ -38,7 +36,6 @@ def create_app(test_config=None):
         pass
 
     db.init_app(app)
-    # migrate.init_app(app=app)
 
     @app.route('/ok')
     def hello():

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -1,5 +1,7 @@
 import hashlib
 import os
+from collections import defaultdict
+
 import pandas as pd
 import json
 from pathlib import Path
@@ -77,3 +79,9 @@ def generate_md5_hash(data: str):
     :return: the md5 hash string
     """
     return hashlib.md5(data.encode()).hexdigest()
+
+
+class PrettyDefaultDict(defaultdict):
+    """An wrapper around defaultdict so the print out looks like
+    a normal dict."""
+    __repr__ = dict.__repr__


### PR DESCRIPTION
Code changes required to wire things up for the backend server UI. Please see the screenshot to check if this makes sense. 

The data shown here are from the task `8a79a035-56fa-415c-8202-9297652dfe75` loaded in the database. Since all the requests have the status of Pending, the outstanding requests are shown as 400 (and 100 per user). 

The rest of the page (Annotations and Model) is shown per label.  We only have one label B2C so only one of these are displayed. 

The basic info section are still extracted from a file.  Are they still valid? If not, what should we change?

<img width="879" alt="image" src="https://user-images.githubusercontent.com/45179326/80134868-61628f00-856d-11ea-9edd-39531605b9bb.png">
