### PR TITLE
Switch NLPModel to use the database

### DIFF
--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -5,7 +5,7 @@ from flask import (
 )
 
 from db.model import (
-    db, Task, TextClassificationModel, FileInference
+    db, Task, Model, TextClassificationModel, FileInference
 )
 from db.utils import get_all_data_files, get_all_pattern_files
 from ar.data import compute_annotation_statistics, \
@@ -16,7 +16,6 @@ from ar.ar_celery import generate_annotation_requests
 from train.train_celery import train_model as local_train_model
 from train.gcp_celery import poll_status as gcp_poll_status
 from train.no_deps.utils import get_env_bool
-from inference.nlp_model import NLPModel
 
 from shared.celery_job_status import (
     CeleryJobStatus, create_status, delete_status
@@ -129,7 +128,7 @@ def show(id):
     # -------------------------------------------------------------------------
     # Models
     models = task.text_classification_models.all()
-    active_model: NLPModel = task.get_active_nlp_model()
+    active_model: Model = task.get_active_nlp_model()
 
     return render_template(
         'tasks/show.html',

--- a/inference/nlp_model.py
+++ b/inference/nlp_model.py
@@ -6,45 +6,38 @@ from train.no_deps.utils import load_original_data_text
 from train.no_deps.inference_results import InferenceResults
 from train.no_deps.paths import _get_inference_fname
 from train.paths import _get_version_dir
+from db.model import Task
 
 
 class NLPModel(ITextCatModel):
     # TODO exploit vs explore
-    def __init__(self, task_id, version):
+    def __init__(self, dbsession, task_id):
+        self.dbsession = dbsession
         self.task_id = task_id
-        self.version = version
         self._cache = None
 
     def __str__(self):
         # Note: This is also used as a cache key.
         return f"NLPModel v{self.version}"
 
-    def _iter_files_and_inferred(self):
-        from db.task import Task
-        task = Task.fetch(self.task_id)
-        for fname in task.get_full_data_fnames():
-
-            text = load_original_data_text(fname)
-
-            version_dir = _get_version_dir(self.task_id, self.version)
-            inf_fname = _get_inference_fname(version_dir, fname)
-            ir = InferenceResults.load(inf_fname)
-
-            probs = ir.probs
-
-            # TODO run any inferences that have not been ran
-            assert len(text) == len(
-                probs), 'Mismatch orig and inferred length. Did original data change?'
-
-            for t, p in zip(text, probs):
-                yield (t, p)
-
     def _warm_up_cache(self):
         if self._cache is None:
             print("Warming up NLPModel cache...")
+
             self._cache = {}
-            for text, pred in self._iter_files_and_inferred():
-                self._cache[_hash_text(text)] = pred
+
+            task = self.dbsession.query(Task).filter_by(
+                id=self.task_id).one_or_none()
+
+            model = task.get_active_nlp_model()
+
+            for inf in model.file_inferences:
+                if inf.input_filename in task.get_data_filenames():
+                    df = inf.create_exported_dataframe(include_text=True)
+                    df['hashed_text'] = df['text'].apply(_hash_text)
+                    self._cache.update(
+                        dict(zip(df['hashed_text'], df['probs'])))
+
         return self._cache
 
     def predict(self, text_list):
@@ -52,12 +45,12 @@ class NLPModel(ITextCatModel):
 
         res = []
         for text in text_list:
-            pred = self._cache.get(_hash_text(text))
-            if pred is None:
+            prob = self._cache.get(_hash_text(text))
+            if prob is None:
                 # TODO run any inferences that have not been ran, instead of silently erroring out
                 res.append({'score': 0., 'prob': None})
             else:
-                res.append({'score': _get_uncertainty(pred), 'prob': pred})
+                res.append({'score': _get_uncertainty(prob), 'prob': prob})
 
         return res
 

--- a/tests/unit/test_nlp_model.py
+++ b/tests/unit/test_nlp_model.py
@@ -1,0 +1,70 @@
+from tests.sqlalchemy_conftest import *
+from db.model import (
+    Task, TextClassificationModel, FileInference
+)
+from inference.nlp_model import NLPModel
+from shared.utils import stem
+import numpy as np
+from numpy import save
+import json
+
+
+def test_create(dbsession, monkeypatch, tmp_path):
+    monkeypatch.setenv('ALCHEMY_FILESTORE_DIR', str(tmp_path))
+
+    # =========================================================================
+    # Create mock files
+
+    model_uuid = "abc"
+    version = 1
+    data_fname = "myfile.csv"
+
+    # Save the data file
+    d = tmp_path / "raw_data"
+    d.mkdir(parents=True)
+
+    p = d / data_fname
+
+    _raw_text = [
+        {"text": "hello", "meta": {"domain": "a.com", "name": "a"}},
+        {"text": "bonjour", "meta": {"domain": "b.com", "name": "b"}},
+        {"text": "nihao", "meta": {"domain": "c.com", "name": "c"}},
+    ]
+    p.write_text("\n".join([json.dumps(t) for t in _raw_text]))
+
+    # Save the predictions
+    d = tmp_path / "models" / model_uuid / str(version) / "inference"
+    d.mkdir(parents=True)
+
+    p = d / f"{stem(data_fname)}.pred.npy"
+    raw_results = np.array([
+        [0.1234, 0.234],
+        [-2.344, 0.100],
+        [-2.344, 0.100],
+    ])
+    save(p, raw_results)
+
+    # A Task has a Model. A Model has a FileInference.
+    task = Task(name="mytask", default_params={
+        'data_filenames': [data_fname]
+    })
+    model = TextClassificationModel(
+        uuid=model_uuid, version=version, task=task)
+    inf = FileInference(model=model, input_filename=data_fname)
+
+    dbsession.add_all([task, model, inf])
+    dbsession.commit()
+
+    # =========================================================================
+    # Using NLPModel
+
+    task = dbsession.query(Task).first()
+
+    # By passing in a task, we'll use the task's latest model's prediction.
+    nlp_model = NLPModel(dbsession, task.id)
+
+    assert nlp_model.predict(['unknown piece of text']) == \
+        [{'score': 0.0, 'prob': None}]
+    assert nlp_model.predict(['hello'])[0]['prob'] > 0
+
+    assert len(nlp_model._cache) == 3


### PR DESCRIPTION
I switched the interface of the `NLPModel` constructor to `NLPModel(dbsession, task_id)`

See the unit test at the end for an example use of `NLPModel`.