### PR TITLE
Add a function to generate entity text lookup function

### DIFF
--- a/shared/utils.py
+++ b/shared/utils.py
@@ -123,3 +123,17 @@ def textarea_to_list(text: str):
     res = [x.strip() for x in text.split('\n')]
     res = [x for x in res if len(x) > 0]
     return res
+
+
+def json_lookup(json_data, key):
+    """
+    Give a key "a.b.c", look up json_data['a']['b']['c']
+    Returns None if any of the keys were not found.
+    """
+    sofar = json_data
+    for k in key.split('.'):
+        try:
+            sofar = sofar[k]
+        except:
+            return None
+    return sofar

--- a/tests/unit/test_shared_utils.py
+++ b/tests/unit/test_shared_utils.py
@@ -1,6 +1,7 @@
 from shared.utils import (
     stem,
     list_to_textarea, textarea_to_list,
+    json_lookup
 )
 
 
@@ -16,3 +17,19 @@ def test_list_to_textarea_and_back():
     ls = ['a', 'bb', 'ccc']
     assert list_to_textarea(ls) == 'a\nbb\nccc'
     assert textarea_to_list(list_to_textarea(ls)) == ls
+
+
+def test_json_lookup():
+    data = {
+        'blah': {
+            'foo': 12,
+            'bar': {
+                'x': 24
+            }
+        }
+    }
+
+    assert json_lookup(data, 'blah.foo') == 12
+    assert json_lookup(data, 'blah.bar.x') == 24
+    assert json_lookup(data, 'blah.foo.x') is None
+    assert json_lookup(data, 'dne') is None

--- a/tests/unit/test_text_lookup.py
+++ b/tests/unit/test_text_lookup.py
@@ -1,0 +1,22 @@
+from shared.utils import save_jsonl
+from train.text_lookup import get_entity_text_lookup_function
+
+
+def test_get_entity_text_lookup_function(monkeypatch, tmp_path):
+    monkeypatch.setenv('ALCHEMY_FILESTORE_DIR', str(tmp_path))
+    dummy_entity_id = 123
+    p = tmp_path / 'data.jsonl'
+    data = [
+        {'text': 'hello world', 'meta': {'name': 'a'}},
+        {'text': 'lorem ipsum', 'meta': {'name': 'b'}},
+    ]
+    save_jsonl(str(p), data)
+
+    fn = get_entity_text_lookup_function(
+        str(p), 'meta.name', 'text', dummy_entity_id)
+
+    assert fn(dummy_entity_id, 'b') == 'lorem ipsum'
+    assert fn(dummy_entity_id, 'a') == 'hello world'
+    assert fn(dummy_entity_id, 'x') == ''
+    assert fn(dummy_entity_id+1, 'a') == ''
+    assert fn(dummy_entity_id+1, 'x') == ''

--- a/train/text_lookup.py
+++ b/train/text_lookup.py
@@ -1,0 +1,55 @@
+from shared.utils import load_jsonl, json_lookup
+
+
+def get_entity_text_lookup_function(jsonl_file_path, entity_name_key,
+                                    entity_text_key, entity_type_id):
+    """
+    Inputs:
+        jsonl_file_path: Path to a jsonl file
+        entity_name_key: Key of the entity name
+        entity_text_key: Key of the text
+        entity_type_id: Limit to only this type of entity.
+
+    Returns:
+        A function of signature (entity_type_id, entity_name)
+        which returns the entity text if found, else return ''
+
+    Example:
+    `jsonl_file_path` points to a file where each line is of the format:
+
+        {
+            'text': 'A search engine',
+            'meta': {
+                'domain': 'google.com',
+            }
+        }
+
+    Then if:
+
+        entity_name_key = 'meta.domain'
+        entity_text_key = 'text'
+        entity_type_id = 1
+
+    Then the resulting lookup function `fn` would behave like:
+
+        fn(1, 'google.com')  =>  'A search engine'
+        fn(1, 'blah.com')  =>  ''
+    """
+
+    data = load_jsonl(jsonl_file_path, to_df=False)
+
+    lookup = {}
+
+    for row in data:
+        name = json_lookup(row, entity_name_key)
+        if name:
+            text = json_lookup(row, entity_text_key) or ''
+            lookup[name] = text
+
+    def fn(_entity_type_id, _entity_name):
+        if entity_type_id == _entity_type_id:
+            return lookup.get(_entity_name, '')
+        else:
+            return ''
+
+    return fn


### PR DESCRIPTION
Add `get_entity_text_lookup_function`, which is a function that returns a function that takes an (entity_type_id, entity_name) and returns the text associated with it. We use this to generate training data.

This function will be used in `ClassificationTrainingData.create_for_label`, which was introduced in https://github.com/edu-gp/annotation_tool/pull/37

