### PR TITLE
Bug fixes

### DIFF
--- a/ar/data.py
+++ b/ar/data.py
@@ -228,11 +228,15 @@ def fetch_ar(task_id, user_id, ar_id):
 
 
 def get_next_ar_id_from_db(dbsession, task_id, user_id, current_ar_id):
-    return dbsession.query(AnnotationRequest.id).filter(
+    res = dbsession.query(AnnotationRequest.id).filter(
         AnnotationRequest.task_id == task_id,
         AnnotationRequest.user_id == user_id,
         AnnotationRequest.id > current_ar_id
-    ).order_by(AnnotationRequest.id.asc()).first()[0]
+    ).order_by(AnnotationRequest.id.asc()).first()
+    if res is not None:
+        return res[0]
+    else:
+        return res
 
 
 def get_next_ar(task_id, user_id, ar_id):

--- a/frontend/static/annotation_box.js
+++ b/frontend/static/annotation_box.js
@@ -99,7 +99,7 @@ class AnnotationBox extends React.Component {
 
         var textStyle = { padding: '5px' };
 
-        if (req.pattern_info !== undefined) {
+        if (req.pattern_info !== undefined && req.pattern_info !== null) {
             let tokens = req.pattern_info.tokens;
             let matches = req.pattern_info.matches;
 

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -60,7 +60,8 @@ def annotate(task_id, ar_id):
     # TODO get_next_ar_id_from_db should just return the AnnotationRequest
     next_req = db.session.query(AnnotationRequest) \
         .filter_by(id=next_ar_id).one_or_none()
-    label = next_req.label
+    # next_req could be None.
+    label = ar_dict['label']
 
     # Fetch all existing annotations on this particular entity done by this
     # user regardless of the label.


### PR DESCRIPTION
- Blacklisting function. Tested by annotating a website `whitesourcesoftware.com` and then request more annotations. Fresh frontend and go through the whole list. No sign of this website. Please double check on your end as well.
- Pattern info is still not shown on my frontend somehow and it complains about the info is null so I have to add additional check for that. Otherwise the text won't show up. It is a separate issue why the info is null in the first place.
- The next_req in the annotate method could be None if there is no next request and that causes an error on the last request page. Besides, we want to get the label for the current request, not the next...