### PR TITLE
Frontend code to export model predictions to a raw data file

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
 from flask import (
     Blueprint, request, jsonify
 )
-from bg.jobs import export_new_raw_data
+from bg.jobs import export_new_raw_data as _export_new_raw_data
 from db.model import db, Model
 
 bp = Blueprint('models', __name__, url_prefix='/models')
@@ -9,26 +9,39 @@ bp = Blueprint('models', __name__, url_prefix='/models')
 # TODO API auth
 
 
+def get_request_data():
+    """Returns a dict of request keys and values, from either json or form"""
+    if len(request.form) > 0:
+        return request.form
+    else:
+        return request.get_json()
+
+
 @bp.route('export_new_raw_data', methods=['POST'])
-def api__export_new_raw_data():
-    data = request.get_json()
+def export_new_raw_data():
+    data = get_request_data()
 
     model_id = int(data.get('model_id'))
     data_fname = data.get('data_fname')
     output_fname = data.get('output_fname')
     cutoff = float(data.get('cutoff'))
 
-    error = None
+    resp = {
+        'error': None,
+        'message': 'Request not processed.'
+    }
+
     try:
         assert data_fname is not None, f"Missing data_fname"
         assert output_fname is not None, f"Missing output_fname"
         assert 0.0 <= cutoff < 1.0, f"Invalid cutoff={cutoff}"
 
         model = db.session.query(Model).filter_by(id=model_id).one_or_none()
-        export_new_raw_data(model, data_fname, output_fname, cutoff=cutoff)
+        output_path = _export_new_raw_data(
+            model, data_fname, output_fname, cutoff=cutoff)
+        resp['message'] = f'Successfully created raw data: {output_path}'
     except Exception as e:
-        error = str(e)
+        resp['error'] = str(e)
+        resp['message'] = f"Error: {resp['error']}"
 
-    return jsonify({
-        'error': error
-    })
+    return jsonify(resp)

--- a/backend/static/style.css
+++ b/backend/static/style.css
@@ -1,0 +1,15 @@
+#fullscreen-loading {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.3);
+    z-index: 999999;
+}
+
+#fullscreen-loading .spinner-border {
+    position: relative;
+    top: 50%;
+    left: 50%;
+}

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -10,6 +10,11 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
     integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 
+  <link rel="stylesheet" href="/static/style.css">
+
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"
+    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+
   <!-- Custom Scripts -->
   {% block head %}{% endblock %}
 
@@ -39,11 +44,13 @@
     </section>
   </div>
 
-  <!-- Optional JavaScript -->
+  <div id="fullscreen-loading" style="display:none">
+    <div class="spinner-border" role="status">
+      <span class="sr-only">Loading...</span>
+    </div>
+  </div>
+
   <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-    integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-    crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
     integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
     crossorigin="anonymous"></script>

--- a/backend/templates/tasks/show.html
+++ b/backend/templates/tasks/show.html
@@ -126,7 +126,7 @@
         <div>
           <form action="{{ url_for('tasks.assign', id=task.id) }}" method="POST">
             <button type="submit" class="btn btn-sm btn-secondary" value={{ task.get_labels() }}>Request
-                More Annotations</button>
+              More Annotations</button>
           </form>
         </div>
 
@@ -247,12 +247,65 @@ length > 0 %}
             <h5>{{mv}}</h5>
 
             {% for fname in mv.get_inference_fnames() %}
-            <div>
-              <form action="{{ url_for('tasks.download_prediction', id=mv.task_id) }}" method="POST">
-                <input type="hidden" name="model_id" value="{{mv.id}}">
-                <input type="hidden" name="fname" value="{{fname}}">
-                <button type="submit" class="btn btn-sm btn-secondary">Download Prediction: "{{fname}}"</button>
-              </form>
+            <div class="row">
+              <div class="col-6">
+                <form action="{{ url_for('tasks.download_prediction', id=mv.task_id) }}" method="POST">
+                  <input type="hidden" name="model_id" value="{{mv.id}}">
+                  <input type="hidden" name="fname" value="{{fname}}">
+                  <button type="submit" class="btn btn-secondary">Download Prediction: "{{fname}}"</button>
+                </form>
+              </div>
+
+              <div class="col-6">
+                <!-- Button trigger modal -->
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
+                  Export to a new raw data file
+                </button>
+              </div>
+
+              <!-- Modal -->
+              <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel"
+                aria-hidden="true">
+                <div class="modal-dialog" role="document">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h5 class="modal-title" id="exampleModalLabel">Export to a new raw data file</h5>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                      </button>
+                    </div>
+
+                    <form class="form-export-new-raw-data">
+                      <div class="modal-body">
+
+                        <input type="hidden" name="_url" value="{{ url_for('models.export_new_raw_data') }}">
+                        <input type="hidden" name="model_id" value="{{mv.id}}">
+                        <input type="hidden" name="data_fname" value="{{fname}}">
+
+                        <div class="form-group">
+                          <label>Output Filename</label>
+                          <input class="form-control" type="text" name="output_fname" required>
+                          <small class="form-text text-muted">
+                            A filename ending in .jsonl
+                          </small>
+                        </div>
+                        <div class="form-group">
+                          <label>Cutoff</label>
+                          <input class="form-control" type="text" name="cutoff" value="0.5" required>
+                          <small class="form-text text-muted">
+                            A value from 0.0 to 1.0
+                          </small>
+                        </div>
+
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Export</button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
             </div>
             {% endfor %}
 
@@ -312,11 +365,6 @@ length > 0 %}
         </p>
       </div>
     </div>
-
-
-
-
-
   </div>
 </div>
 
@@ -347,6 +395,35 @@ length > 0 %}
       }
     }
   }
+
+  function showLoadingScreen() {
+    $("#fullscreen-loading").css('display', '');
+  }
+
+  function hideLoadingScreen() {
+    $("#fullscreen-loading").css('display', 'none');
+  }
+
+  $('form.form-export-new-raw-data').submit(function (event) {
+    event.preventDefault();
+
+    var $inputs = $(event.target).find(':input');
+    var values = {};
+    $inputs.each(function () {
+      values[this.name] = $(this).val();
+    });
+
+    event.preventDefault();
+
+    $.post(values['_url'], values, function (data) {
+      hideLoadingScreen();
+      alert(data['message']);
+    });
+
+    $(event.target).parents().modal('hide');
+
+    showLoadingScreen();
+  })
 
 </script>
 {% endblock %}


### PR DESCRIPTION
Following up to https://github.com/edu-gp/annotation_tool/pull/62, this adds the frontend changes to expose this in the UI.

This adds a blue button to export the data:
<img width="714" alt="Screen Shot 2020-05-08 at 2 53 02 PM" src="https://user-images.githubusercontent.com/46904813/81439006-aecd2780-913b-11ea-8a41-4a1d23f70621.png">

When clicked a modal pops up:
<img width="557" alt="Screen Shot 2020-05-08 at 2 53 18 PM" src="https://user-images.githubusercontent.com/46904813/81439028-bab8e980-913b-11ea-8f0c-17109755c5db.png">

After the user submits, a spinner is shown.
<img width="321" alt="Screen Shot 2020-05-08 at 2 54 33 PM" src="https://user-images.githubusercontent.com/46904813/81439113-dde39900-913b-11ea-8908-848b290e2fcb.png">

When a response comes back, it's displayed as an alert.
<img width="598" alt="Screen Shot 2020-05-08 at 2 54 39 PM" src="https://user-images.githubusercontent.com/46904813/81439126-e2a84d00-913b-11ea-9e6c-f171bed35b32.png">

