### PR TITLE
Run submit-to-GCP-training job on Celery

### DIFF
--- a/ar/ar_celery.py
+++ b/ar/ar_celery.py
@@ -64,6 +64,8 @@ def generate_annotation_requests(task_id, max_per_annotator,
 
     set_status(celery_id, JobStatus.DONE, progress=1.0)
 
+    db.session.close()
+
 
 app.conf.task_routes = {'*.ar_celery.*': {'queue': 'ar_celery'}}
 

--- a/train/train_celery.py
+++ b/train/train_celery.py
@@ -6,6 +6,8 @@ from train.no_deps.run import (
     train_model as _train_model,
     inference as _inference
 )
+from train.gcp_job import GCPJob
+from train.gcp_celery import poll_status as gcp_poll_status
 
 app = Celery(
     # module name
@@ -26,24 +28,51 @@ app = Celery(
 @app.task
 def train_model(task_id):
     db = Database.from_config(DevelopmentConfig)
-    model = prepare_task_for_training(db.session, task_id)
-    model_dir = model.dir(abs=True)
+    try:
+        model = prepare_task_for_training(db.session, task_id)
+        model_dir = model.dir(abs=True)
 
-    _train_model(model_dir)
+        _train_model(model_dir)
 
-    # Note: It appears inference can be faster if it's allowed to use all the GPU memory,
-    # however the only way to clear all GPU memory is to end this task. So we call inference
-    # asynchronously so this task can end.
-    inference.delay(task_id, model_dir)
+        # Note: It appears inference can be faster if it's allowed to use all the GPU memory,
+        # however the only way to clear all GPU memory is to end this task. So we call inference
+        # asynchronously so this task can end.
+        inference.delay(task_id, model_dir)
+    finally:
+        db.session.close()
 
 
 @app.task
 def inference(task_id, model_dir):
     db = Database.from_config(DevelopmentConfig)
-    task = db.session.query(Task).filter_by(id=task_id).one_or_none()
-    fnames = task.get_data_filenames(abs=True)
+    try:
+        task = db.session.query(Task).filter_by(id=task_id).one_or_none()
+        fnames = task.get_data_filenames(abs=True)
 
-    _inference(model_dir, fnames)
+        _inference(model_dir, fnames)
+    finally:
+        db.session.close()
+
+
+@app.task
+def submit_gcp_training(task_id):
+    db = Database.from_config(DevelopmentConfig)
+    try:
+        task = db.session.query(Task).filter_by(id=task_id).one_or_none()
+
+        model = prepare_task_for_training(db.session, task.id)
+
+        files_for_inference = task.get_data_filenames(abs=True)
+
+        job = GCPJob(model.uuid, model.version)
+
+        # TODO: A duplicate job would error out. Currently errors for
+        # background jobs are silent...
+        job.submit(files_for_inference)
+
+        gcp_poll_status.delay(model.id)
+    finally:
+        db.session.close()
 
 
 app.conf.task_routes = {'*.train_celery.*': {'queue': 'train_celery'}}


### PR DESCRIPTION
1. The submit-to-GCP-training job used to run just on the web server. It's now moved to Celery.
2. I added the following pattern to all the Celery jobs. It fixes a minor error, just for correctness.
```
db = Database(...)
try:
     ...
finally:
     db.session.close()
``` 