### PR TITLE
Disable selecting multiple files when creating a Task

### DIFF
--- a/backend/templates/tasks/new.html
+++ b/backend/templates/tasks/new.html
@@ -28,10 +28,9 @@
 
       <div class="form-group">
         <label for="data">What data will we annotate?</label>
-        <small class="form-text text-muted mt-0 mb-2">You can select multiple files.</small>
         {% for fname in data_fnames %}
         <div class="form-check">
-          <input class="form-check-input" type="checkbox" name="data" value="{{fname}}" id="data_{{fname}}"
+          <input class="form-check-input" type="radio" name="data" value="{{fname}}" id="data_{{fname}}"
             {{'checked' if fname in request.form.getlist('data') else ''}}>
           <label class="form-check-label" for="data_{{fname}}">
             {{fname}}


### PR DESCRIPTION
Only allow a user to select 1 file when creating a task. In the new workflow, the benefit of selecting multiple files is not clear.. so let's keep it simple until we have a good reason to enable it again.