### PR TITLE
Using pattern model for each label to create pattern matches. Fix bug

### DIFF
--- a/ar/__init__.py
+++ b/ar/__init__.py
@@ -197,9 +197,25 @@ def generate_annotation_requests(dbsession, task_id: int,
         __text_list.append(row['text'])
 
     # Pattern decorations
+    __pattern_decor_for_all_labels = []
     if task.get_pattern_model():
-        __pattern_decor = task.get_pattern_model().predict(__text_list,
-                                                           fancy=True)
+        labels = task.get_labels()  # ["hotdog", "fake"]
+        logging.error(labels)
+        for label in labels:
+            pattern_model_for_label = get_pattern_model_for_label(
+                dbsession=dbsession, label=label)
+            logging.error(pattern_model_for_label)
+            if pattern_model_for_label:
+                __pattern_decor_for_label = pattern_model_for_label.predict(
+                    __text_list, fancy=True
+                )
+                __pattern_decor_for_all_labels.append(__pattern_decor_for_label)
+
+        __pattern_decor = _merge_pattern_decor_for_all_labels_recursive(
+            pattern_decor_for_all_labels=__pattern_decor_for_all_labels,
+            low=0,
+            high=len(__pattern_decor_for_all_labels) - 1
+        )
     else:
         __pattern_decor = None
 
@@ -221,6 +237,49 @@ def generate_annotation_requests(dbsession, task_id: int,
 
     logging.info("Finished generating annotation requests.")
     return annotation_requests
+
+
+def _merge_pattern_decor_for_all_labels_recursive(
+        pattern_decor_for_all_labels: List[List], low: int, high: int):
+    if len(pattern_decor_for_all_labels) == 0:
+        return None
+    if low == high:
+        return pattern_decor_for_all_labels[low]
+    if low > high:
+        return None
+
+    mid = low + (high - low) // 2
+    left_merged = _merge_pattern_decor_for_all_labels_recursive(
+        pattern_decor_for_all_labels, low, mid
+    )
+    right_merged = _merge_pattern_decor_for_all_labels_recursive(
+        pattern_decor_for_all_labels, mid + 1, high
+    )
+
+    return _merge_two_pattern_decors(left_merged, right_merged)
+
+
+def _merge_two_pattern_decors(pattern_decor1: List, pattern_decor2: List):
+    res = pattern_decor1.copy()
+    for i, item in enumerate(pattern_decor2):
+        # Tokens for the same entity are the same so need to merge them.
+
+        res[i]['matches'].extend(item['matches'])
+
+        # In case we need the scores later on, they are merged into a list
+        if not isinstance(res[i]['score'], list):
+            res[i]['score'] = [res[i]['score']]
+
+        if isinstance(item['score'], list):
+            res[i]['score'].extend(item['score'])
+        else:
+            res[i]['score'].append(item['score'])
+
+    # Dedup the merged matching positions.
+    for item in res:
+        item['matches'] = sorted(list(set(item['matches'])))
+
+    return res
 
 
 def _build_blacklisting_lookup_dict(dbsession):

--- a/ar/data.py
+++ b/ar/data.py
@@ -226,51 +226,6 @@ def construct_annotation_dict(dbsession, annotation_id) -> Dict:
     return result
 
 
-# TODO refactor this piece since it's a duplicate of the ar_request function.
-def construct_annotation_dict(dbsession, annotation_id) -> Dict:
-    annotation_id, entity, entity_type, label, context = dbsession.query(
-        ClassificationAnnotation.id,
-        ClassificationAnnotation.entity,
-        ClassificationAnnotation.entity_type,
-        ClassificationAnnotation.label,
-        ClassificationAnnotation.context). \
-        filter(ClassificationAnnotation.id == annotation_id).one_or_none()
-
-    result = {
-        # Essential fields
-        'annotation_id': annotation_id,
-        'entity': entity,
-        'entity_type': entity_type,
-        'label': label,
-        # Optional fields
-        'fname': None,
-        'line_number': None,
-        'score': None,
-        'data': None,
-        'pattern_info': None,
-    }
-
-    if context is not None and isinstance(context, dict):
-        result.update({
-            'fname': context.get('fname'),
-            'line_number': context.get('line_number'),
-            'score': context.get('score'),
-            'data': context.get('data') if 'data' in context else context,
-            'pattern_info': context.get('pattern_info'),
-        })
-    else:
-        # TODO this is a temporarily workaround since some entities only
-        #  have annotations but not annotation requests in my local db and
-        #  they are not from Salesforce. Weird...
-        #  I can't run backfill on the context column so I have to hardcode
-        #  a text field to show the description on the frontend.
-        result.update({
-            'data': {"text": context}
-        })
-
-    return result
-
-
 def construct_ar_request_dict(dbsession, ar_id) -> Dict:
     request_id, entity, entity_type, label, context = dbsession.query(
         AnnotationRequest.id,

--- a/ar/data.py
+++ b/ar/data.py
@@ -182,6 +182,50 @@ def fetch_all_ar(task_id, username):
     return _get_all_ar_ids_in_dir(_dir, sort_by_ctime=True)
 
 
+def construct_annotation_dict(dbsession, annotation_id) -> Dict:
+    annotation_id, entity, entity_type, label, context = dbsession.query(
+        ClassificationAnnotation.id,
+        ClassificationAnnotation.entity,
+        ClassificationAnnotation.entity_type,
+        ClassificationAnnotation.label,
+        ClassificationAnnotation.context). \
+        filter(ClassificationAnnotation.id == annotation_id).one_or_none()
+
+    result = {
+        # Essential fields
+        'annotation_id': annotation_id,
+        'entity': entity,
+        'entity_type': entity_type,
+        'label': label,
+        # Optional fields
+        'fname': None,
+        'line_number': None,
+        'score': None,
+        'data': None,
+        'pattern_info': None,
+    }
+
+    if context is not None and isinstance(context, dict):
+        result.update({
+            'fname': context.get('fname'),
+            'line_number': context.get('line_number'),
+            'score': context.get('score'),
+            'data': context.get('data') if 'data' in context else context,
+            'pattern_info': context.get('pattern_info'),
+        })
+    else:
+        # TODO this is a temporarily workaround since some entities only
+        #  have annotations but not annotation requests in my local db and
+        #  they are not from Salesforce. Weird...
+        #  I can't run backfill on the context column so I have to hardcode
+        #  a text field to show the description on the frontend.
+        result.update({
+            'data': {"text": context}
+        })
+
+    return result
+
+
 # TODO refactor this piece since it's a duplicate of the ar_request function.
 def construct_annotation_dict(dbsession, annotation_id) -> Dict:
     annotation_id, entity, entity_type, label, context = dbsession.query(

--- a/tests/unit/test_merge_pattern_decor.py
+++ b/tests/unit/test_merge_pattern_decor.py
@@ -1,0 +1,31 @@
+from ar import _merge_pattern_decor_for_all_labels_recursive
+
+
+def test_merge_pattern_decor():
+    pattern_decor1 = [
+        {'token': ['a', 'b', 'c'], 'matches': [(0, 1, 'a')], 'score': 0.09},
+        {'token': ['b', 'e', 'd'], 'matches': [(0, 1, 'b'), (1, 2, 'e')],
+         'score': 0.06},
+    ]
+
+    pattern_decor2 = [
+        {'token': ['a', 'b', 'c'], 'matches': [(1, 2, 'b')], 'score': 0.06},
+        {'token': ['b', 'e', 'd'], 'matches': [(1, 2, 'e'), (2, 3, 'd')],
+         'score': 0.09},
+    ]
+
+    pattern_decors = [pattern_decor1, pattern_decor2]
+    res = _merge_pattern_decor_for_all_labels_recursive(
+        pattern_decor_for_all_labels=pattern_decors,
+        low=0,
+        high=len(pattern_decors) - 1
+    )
+    print(res)
+    assert res == [
+        {'token': ['a', 'b', 'c'],
+         'matches': [(0, 1, 'a'), (1, 2, 'b')],
+         'score': [0.09, 0.06]},
+        {'token': ['b', 'e', 'd'],
+         'matches': [(0, 1, 'b'), (1, 2, 'e'), (2, 3, 'd')],
+         'score': [0.06, 0.09]}
+    ]


### PR DESCRIPTION
- Use pattern model for labels
- Merge pattern models from different labels together. For the same entity, the tokens are the same. All matches are grouped together and sorted (easier for unit test). The scores are also saved although I don't know how we are going to display the scores for multiple labels.


