### PR TITLE
Various bug fixes

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -37,6 +37,8 @@ def export_new_raw_data():
         assert output_fname is not None, f"Missing output_fname"
         assert 0.0 <= cutoff < 1.0, f"Invalid cutoff={cutoff}"
 
+        output_fname = output_fname.replace(' ', '_')
+
         model = db.session.query(Model).filter_by(id=model_id).one_or_none()
         output_path = _export_new_raw_data(
             model, data_fname, output_fname, cutoff=cutoff)

--- a/backend/templates/tasks/edit.html
+++ b/backend/templates/tasks/edit.html
@@ -25,6 +25,12 @@
       value="{{ request.form['name'] | default(task.name) }}" required>
   </div>
 
+  <div class="form-group">
+    <label for="name">Data</label>
+    <input type="text" class="form-control" name="data" id="data"
+      value="{{ request.form['data'] | default(task.get_data_filenames()[0]) }}" required>
+  </div>
+
   <div class="row">
     <div class="col">
 

--- a/backend/templates/tasks/show.html
+++ b/backend/templates/tasks/show.html
@@ -308,6 +308,7 @@
               <div class="card-body">
                 <h5>
                   Version {{mv.version}}
+                  ({{mv.created_at.strftime('%Y-%m-%d')}})
                   <small class='text-muted ml-3'>{{mv.uuid}}</small>
                 </h5>
 

--- a/bg/jobs.py
+++ b/bg/jobs.py
@@ -17,6 +17,7 @@ def export_new_raw_data(model: Model, data_fname: str, output_fname: str,
 
     if not output_fname.endswith('.jsonl'):
         output_fname += '.jsonl'
+    output_fname = output_fname.replace(' ', '_')
     output_path = _raw_data_file_path(output_fname)
 
     if os.path.isfile(output_path):

--- a/scripts/export_annotations.py
+++ b/scripts/export_annotations.py
@@ -1,0 +1,27 @@
+from db.model import Database, ClassificationAnnotation
+from db.config import DevelopmentConfig
+import pandas as pd
+from tqdm import tqdm
+import time
+
+db = Database(DevelopmentConfig.SQLALCHEMY_DATABASE_URI)
+
+if __name__ == "__main__":
+    query = db.session.query(ClassificationAnnotation)
+
+    count = query.count()
+    print(f"Exporting {count} Annotations")
+
+    bs = 50
+
+    res = []
+    for el in tqdm(query.yield_per(bs), total=count):
+        res.append(
+            (el.id, el.entity_type, el.entity, el.user_id, el.label, el.value))
+
+    res = pd.DataFrame(res, columns=[
+        'id', 'entity_type', 'entity', 'user_id', 'label', 'value'])
+
+    now = int(time.time())
+    res.to_csv(f'/tmp/annotations_{now}.csv', index=False)
+


### PR DESCRIPTION
1. When exporting a new dataset, make sure the dataset name has no spaces by replacing all of them with an underscore. Spaces may cause issues when we submit the job for remote training.
2. It's better to display trained models in the order in which they were created, and then show the time they were created at.
3. Allow the user to edit each Task's data filename.
4. Include a script to export annotations.