### PR TITLE
Adding progress display on the annotate page for requests

### DIFF
--- a/ar/data.py
+++ b/ar/data.py
@@ -175,14 +175,6 @@ def fetch_ar_id_and_status(dbsession, task_id, username):
     return query.all()
 
 
-def count_ar_under_task_and_user(dbsession, task_id, username):
-    res = dbsession.query(func.count(AnnotationRequest.id)) \
-        .join(User) \
-        .filter(User.username == username,
-                AnnotationRequest.task_id == task_id).all()
-    return res[0][0]
-
-
 # TODO delete after the migration to db is done.
 def fetch_all_ar(task_id, username):
     '''

--- a/ar/data.py
+++ b/ar/data.py
@@ -175,6 +175,14 @@ def fetch_ar_id_and_status(dbsession, task_id, username):
     return query.all()
 
 
+def count_ar_under_task_and_user(dbsession, task_id, username):
+    res = dbsession.query(func.count(AnnotationRequest.id)) \
+        .join(User) \
+        .filter(User.username == username,
+                AnnotationRequest.task_id == task_id).all()
+    return res[0][0]
+
+
 # TODO delete after the migration to db is done.
 def fetch_all_ar(task_id, username):
     '''

--- a/ar/data.py
+++ b/ar/data.py
@@ -183,6 +183,16 @@ def count_ar_under_task_and_user(dbsession, task_id, username):
     return res[0][0]
 
 
+def count_completed_ar_under_task_and_user(dbsession, task_id, username):
+    res = dbsession.query(func.count(AnnotationRequest.id)) \
+        .join(User) \
+        .filter(User.username == username,
+                AnnotationRequest.task_id == task_id,
+                AnnotationRequest.status == AnnotationRequestStatus.Complete)\
+        .all()
+    return res[0][0]
+
+
 # TODO delete after the migration to db is done.
 def fetch_all_ar(task_id, username):
     '''

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -191,7 +191,7 @@ def receive_annotation():
 
     if next_ar_id:
         return {'redirect': url_for('tasks.annotate', task_id=task_id,
-                                    ar_id=next_ar_id, item_id=item_id)}
+                                    ar_id=next_ar_id)}
     else:
         return {'redirect': url_for('tasks.show', id=task_id)}
 

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -119,10 +119,15 @@ def annotate(task_id, ar_id):
     anno["update_redirect_link"] = url_for('tasks.show', id=task_id)
     anno["task_page_name"] = "Task"
 
-    anno["item_id"] = request.args.get("item_id", None)
-    anno["total_size"] = count_ar_under_task_and_user(dbsession=db.session,
-                                                      task_id=task_id,
-                                                      username=annotator)
+    ar_id_and_status_pairs = fetch_ar_id_and_status(dbsession=db.session,
+                                                    task_id=task_id,
+                                                    username=annotator)
+
+    anno["total_size"] = len(ar_id_and_status_pairs)
+    anno["item_id"] = sum(
+        [1 if pair[1] == AnnotationRequestStatus.Complete else 0
+         for pair in ar_id_and_status_pairs]
+    )
 
     return render_template('tasks/annotate.html',
                            task=task,

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -7,7 +7,7 @@ from ar.data import (
     build_empty_annotation, construct_ar_request_dict,
     get_next_ar_id_from_db, fetch_user_id_by_username,
     fetch_ar_id_and_status, construct_annotation_dict,
-    _construct_comparison_df, count_ar_under_task_and_user)
+    _construct_comparison_df)
 import json
 from flask import (
     Blueprint, g, render_template, request, url_for)

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -7,7 +7,7 @@ from ar.data import (
     build_empty_annotation, construct_ar_request_dict,
     get_next_ar_id_from_db, fetch_user_id_by_username,
     fetch_ar_id_and_status, construct_annotation_dict,
-    _construct_comparison_df)
+    _construct_comparison_df, count_ar_under_task_and_user)
 import json
 from flask import (
     Blueprint, g, render_template, request, url_for)

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -118,6 +118,9 @@ def annotate(task_id, ar_id):
     anno["update_redirect_link"] = url_for('tasks.show', id=task_id)
     anno["task_page_name"] = "Task"
 
+    anno["item_id"] = request.args.get("item_id", None)
+    anno["total_size"] = request.args.get("total_size", None)
+
     return render_template('tasks/annotate.html',
                            task=task,
                            anno=anno,
@@ -137,6 +140,9 @@ def receive_annotation():
     ar_id = data['req']['ar_id']
     entity_type = data['req']['entity_type']
     entity = data['req']['entity']
+
+    item_id = int(data['item_id']) + 1
+    total_size = data['total_size']
 
     context = {
         'data': data['req']['data'],
@@ -177,7 +183,8 @@ def receive_annotation():
 
     if next_ar_id:
         return {'redirect': url_for('tasks.annotate', task_id=task_id,
-                                    ar_id=next_ar_id)}
+                                    ar_id=next_ar_id, item_id=item_id,
+                                    total_size=total_size)}
     else:
         return {'redirect': url_for('tasks.show', id=task_id)}
 

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -7,7 +7,8 @@ from ar.data import (
     build_empty_annotation, construct_ar_request_dict,
     get_next_ar_id_from_db, fetch_user_id_by_username,
     fetch_ar_id_and_status, construct_annotation_dict,
-    _construct_comparison_df, count_ar_under_task_and_user)
+    _construct_comparison_df, count_ar_under_task_and_user,
+    count_completed_ar_under_task_and_user)
 import json
 from flask import (
     Blueprint, g, render_template, request, url_for)
@@ -119,14 +120,14 @@ def annotate(task_id, ar_id):
     anno["update_redirect_link"] = url_for('tasks.show', id=task_id)
     anno["task_page_name"] = "Task"
 
-    ar_id_and_status_pairs = fetch_ar_id_and_status(dbsession=db.session,
-                                                    task_id=task_id,
-                                                    username=annotator)
+    anno["total_size"] = count_ar_under_task_and_user(dbsession=db.session,
+                                                      task_id=task_id,
+                                                      username=annotator)
 
-    anno["total_size"] = len(ar_id_and_status_pairs)
-    anno["item_id"] = sum(
-        [1 if pair[1] == AnnotationRequestStatus.Complete else 0
-         for pair in ar_id_and_status_pairs]
+    anno["item_id"] = count_completed_ar_under_task_and_user(
+        dbsession=db.session,
+        task_id=task_id,
+        username=annotator
     )
 
     return render_template('tasks/annotate.html',

--- a/frontend/templates/tasks/annotate.html
+++ b/frontend/templates/tasks/annotate.html
@@ -29,7 +29,11 @@
         <a href="{{ anno["update_redirect_link"] }}">{{ anno["task_page_name"] }}</a>
     </li>
     <li class="breadcrumb-item active" aria-current="page">
-      Example
+        {% if anno["item_id"] and anno["total_size"] %}
+           Example ({{ anno["item_id"] }} / {{ anno["total_size"] }})
+        {% else %}
+           Example
+        {% endif %}
     </li>
   </ol>
 </nav>

--- a/frontend/templates/tasks/annotate.html
+++ b/frontend/templates/tasks/annotate.html
@@ -29,11 +29,7 @@
         <a href="{{ anno["update_redirect_link"] }}">{{ anno["task_page_name"] }}</a>
     </li>
     <li class="breadcrumb-item active" aria-current="page">
-        {% if anno["item_id"] and anno["total_size"] %}
-           Example ({{ anno["item_id"] }} / {{ anno["total_size"] }})
-        {% else %}
-           Example
-        {% endif %}
+        Example
     </li>
   </ol>
 </nav>
@@ -41,6 +37,12 @@
 
 {% block content %}
 <div class="text-center">
+  <h6>
+      {% if anno["item_id"] and anno["total_size"] %}
+           Progress: Done {{ anno["item_id"] }} / Total {{
+                anno["total_size"] }}
+        {% endif %}
+  </h6>
   <h6>
       {% if anno['is_new_annotation'] == True %}
           Task "{{task.name}}" AR #{{anno['req']['ar_id']}}
@@ -58,7 +60,7 @@
     {% if next_ar_id or anno['is_admin_correction'] %}
         <a style="display:block" class="btn btn-secondary m-auto"
            href={{url_for('tasks.annotate', task_id=task.id,
-                ar_id=next_ar_id, item_id=((anno['item_id'] | int) + 1))
+                ar_id=next_ar_id)
                 }}>Skip</a>
     {% elif next_annotation_id %}
          <a style="display:block" class="btn btn-secondary m-auto" href={{url_for('tasks.reannotate', task_id=task.id, annotation_id=next_annotation_id)

--- a/frontend/templates/tasks/annotate.html
+++ b/frontend/templates/tasks/annotate.html
@@ -56,7 +56,9 @@
   </div>
   <div class="col">
     {% if next_ar_id or anno['is_admin_correction'] %}
-        <a style="display:block" class="btn btn-secondary m-auto" href={{url_for('tasks.annotate', task_id=task.id, ar_id=next_ar_id)
+        <a style="display:block" class="btn btn-secondary m-auto"
+           href={{url_for('tasks.annotate', task_id=task.id,
+                ar_id=next_ar_id, item_id=((anno['item_id'] | int) + 1))
                 }}>Skip</a>
     {% elif next_annotation_id %}
          <a style="display:block" class="btn btn-secondary m-auto" href={{url_for('tasks.reannotate', task_id=task.id, annotation_id=next_annotation_id)

--- a/frontend/templates/tasks/show.html
+++ b/frontend/templates/tasks/show.html
@@ -43,7 +43,7 @@
       </td>
       <td>
         <a class="mx-2" href={{url_for('tasks.annotate', task_id=task.id,
-                ar_id=ar_id, item_id=loop.index, total_size=ars | length)}}>
+                ar_id=ar_id, item_id=loop.index)}}>
           Example #{{ar_id}}
         </a>
       </td>

--- a/frontend/templates/tasks/show.html
+++ b/frontend/templates/tasks/show.html
@@ -42,7 +42,8 @@
         {% endif %}
       </td>
       <td>
-        <a class="mx-2" href={{url_for('tasks.annotate', task_id=task.id, ar_id=ar_id)}}>
+        <a class="mx-2" href={{url_for('tasks.annotate', task_id=task.id,
+                ar_id=ar_id, item_id=loop.index, total_size=ars | length)}}>
           Example #{{ar_id}}
         </a>
       </td>

--- a/frontend/templates/tasks/show.html
+++ b/frontend/templates/tasks/show.html
@@ -43,7 +43,7 @@
       </td>
       <td>
         <a class="mx-2" href={{url_for('tasks.annotate', task_id=task.id,
-                ar_id=ar_id, item_id=loop.index)}}>
+                ar_id=ar_id)}}>
           Example #{{ar_id}}
         </a>
       </td>


### PR DESCRIPTION
Progress bar for annotating requests. It seems we need to pass around the list id and total number of requests in the URL. Otherwise we may need to write queries for every page.