### PR TITLE
Use ENV variable to replace the db_url in alembic ini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ CLOUDSDK_COMPUTE_REGION=us-central1
 ALCHEMY_FILESTORE_DIR=__filestore
 ALCHEMY_DATABASE_URI=sqlite:////annotation_tool/alchemy.db
 GCP_PROJECT_ID=
+DB_URL_FOR_MIGRATION=

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Descriptions of the env vars:
 - `GOOGLE_AI_PLATFORM_DOCKER_IMAGE_URI`: Distributed Training - pre-built training image URI.
 - `CLOUDSDK_COMPUTE_REGION`: The GCP region, e.g. "us-central1". You must set this in order for Google AI Platform to work.
 - `GCP_PROJECT_ID`: The id of the current project on GCP
+- `DB_URL_FOR_MIGRATION`: The link to the database instance when running migration.
 
 New env vars:
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -35,7 +35,7 @@ script_location = alembic
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = sqlite:///alchemy.db
+sqlalchemy.url =
 
 
 [post_write_hooks]

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -6,12 +7,19 @@ from sqlalchemy import pool
 from alembic import context
 
 import sys
+import logging
 
 sys.path = ['', '..'] + sys.path[1:]
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+db_url = os.environ.get("DB_URL_FOR_MIGRATION", None)
+if db_url:
+    logging.info("DB_URL is {}".format(db_url))
+    config.set_main_option('sqlalchemy.url', db_url)
+else:
+    raise ValueError("DB URL is not specified.")
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.


### PR DESCRIPTION
Use environment variable to replace the db_url in the alembic ini file. This is only used for DB migration purpose. Locally it works but we will need to test it on the prod server with the real DB to verify if it works there.