### PR TITLE
Adding try except block vs tear_down_request

### DIFF
--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -46,29 +46,14 @@ def create_app(test_config=None):
     @login_required
     def index():
         username = g.user['username']
-        task_ids = fetch_tasks_for_user(username)
         task_id_and_name_pairs = fetch_tasks_for_user_from_db(
             db.session, username)
-        # tasks = [Task.fetch(task_id) for task_id in task_ids]
         return render_template('index.html', tasks=task_id_and_name_pairs)
 
     @app.route('/secret')
     @login_required
     def secret():
         return render_template('secret.html')
-
-    # @app.teardown_request
-    # def teardown_request_func(error=None):
-    #     if error:
-    #         logging.error(error)
-    #         db.session.rollback()
-    #         raise error
-    #     try:
-    #         db.session.commit()
-    #     except DatabaseError as e:
-    #         logging.error(e)
-    #         db.session.rollback()
-    #         raise e
 
     from . import auth
     app.register_blueprint(auth.bp)

--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -4,6 +4,7 @@ import os
 from flask import (
     Flask, render_template, g
 )
+from sqlalchemy.exc import DatabaseError
 
 from db.model import db
 from db.config import DevelopmentConfig
@@ -55,6 +56,19 @@ def create_app(test_config=None):
     @login_required
     def secret():
         return render_template('secret.html')
+
+    # @app.teardown_request
+    # def teardown_request_func(error=None):
+    #     if error:
+    #         logging.error(error)
+    #         db.session.rollback()
+    #         raise error
+    #     try:
+    #         db.session.commit()
+    #     except DatabaseError as e:
+    #         logging.error(e)
+    #         db.session.rollback()
+    #         raise e
 
     from . import auth
     app.register_blueprint(auth.bp)

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Tuple
 
+from sqlalchemy.exc import DatabaseError
 from werkzeug.urls import url_decode
 
 from ar.data import (
@@ -269,8 +270,11 @@ def update_annotation():
                 context=context
             )
         db.session.add(annotation)
-
-    db.session.commit()
+    try:
+        db.session.commit()
+    except DatabaseError:
+        db.session.rollback()
+        raise
 
     return {'redirect': data.get('update_redirect_link')}
 


### PR DESCRIPTION
We can either wrap try-except on every commit or use the `tear_down_request` to handle the commit and rollback (see the commented-out code block). 

The tear_down_request will be executed after each request even if the request failed. My only concern is that it makes me uncomfortable not seeing try-catch block after we use `db.session.add` in the controller code. I have to mentally recall the `tear_down_request` is handling it. What's your thought on this?