### PR TITLE
Adding the source column with a one-time backfill script

### DIFF
--- a/backend/annotations.py
+++ b/backend/annotations.py
@@ -3,8 +3,8 @@ from flask import (
 )
 from db.model import (
     db, EntityTypeEnum,
-    ClassificationAnnotation, User, get_or_create
-)
+    ClassificationAnnotation, User, get_or_create,
+    AnnotationSource)
 from .annotations_utils import parse_form
 
 from .auth import auth
@@ -77,7 +77,8 @@ def bulk_post():
                             "name": domain,
                             "domain": domain
                         }
-                    }
+                    },
+                    source=AnnotationSource.ALCHMEY
                 )
             else:
                 anno.value = annotation

--- a/db/model.py
+++ b/db/model.py
@@ -97,6 +97,10 @@ DUMMY_ENTITY = '__dummy__'
 # Tables
 
 
+class PredefinedUserName:
+    SALESFORCE_BOT = "salesforce_bot"
+
+
 class User(Base):
     __tablename__ = 'user'
     id = Column(Integer, primary_key=True)
@@ -139,6 +143,12 @@ class User(Base):
         return q.all()
 
 
+class AnnotationSource:
+    ALCHMEY = "Alchemy"
+    SALESFORCE = "salesforce"
+    OTHER = "other"
+
+
 class ClassificationAnnotation(Base):
     __tablename__ = 'classification_annotation'
 
@@ -154,6 +164,9 @@ class ClassificationAnnotation(Base):
 
     user_id = Column(Integer, ForeignKey('user.id'))
     user = relationship("User", back_populates="classification_annotations")
+
+    source = Column(String, index=True, nullable=True,
+                    default=AnnotationSource.ALCHMEY)
 
     context = Column(JSON)
     """
@@ -177,6 +190,7 @@ class ClassificationAnnotation(Base):
         Value {},
         Created at {},
         Last Updated at {}
+        Source {}
         """.format(
             self.id,
             self.entity,
@@ -185,7 +199,8 @@ class ClassificationAnnotation(Base):
             self.user_id,
             self.value,
             self.created_at,
-            self.updated_at
+            self.updated_at,
+            self.source
         )
 
     @staticmethod
@@ -196,7 +211,8 @@ class ClassificationAnnotation(Base):
                              entity=DUMMY_ENTITY,
                              entity_type=entity_type,
                              label=label,
-                             value=AnnotationValue.NOT_ANNOTATED)
+                             value=AnnotationValue.NOT_ANNOTATED,
+                             source=AnnotationSource.ALCHMEY)
 
 
 def majority_vote_annotations_query(dbsession, label):

--- a/frontend/tasks.py
+++ b/frontend/tasks.py
@@ -16,7 +16,8 @@ from flask import (
 from db.model import (
     db, AnnotationRequest, Task, get_or_create, ClassificationAnnotation,
     AnnotationGuide, AnnotationValue, AnnotationRequestStatus,
-    fetch_annotation_entity_and_ids_done_by_user_under_labels, User)
+    fetch_annotation_entity_and_ids_done_by_user_under_labels, User,
+    AnnotationSource)
 
 from .auth import login_required
 
@@ -169,7 +170,8 @@ def receive_annotation():
                                    label=label,
                                    user_id=user_id,
                                    context=context,
-                                   value=AnnotationValue.NOT_ANNOTATED)
+                                   value=AnnotationValue.NOT_ANNOTATED,
+                                   source=AnnotationSource.ALCHMEY)
         annotation.value = value
         db.session.add(annotation)
 
@@ -266,7 +268,8 @@ def update_annotation():
                 entity=entity,
                 user_id=annotation_owner.id,
                 value=value,
-                context=context
+                context=context,
+                source=AnnotationSource.ALCHMEY
             )
         db.session.add(annotation)
 

--- a/scripts/migrate_json_to_db.py
+++ b/scripts/migrate_json_to_db.py
@@ -26,8 +26,8 @@ from db.model import (
     EntityTypeEnum, AnnotationRequestStatus, AnnotationType,
     User, Task,
     AnnotationRequest, ClassificationAnnotation,
-    ClassificationTrainingData, TextClassificationModel
-)
+    ClassificationTrainingData, TextClassificationModel,
+    AnnotationSource)
 from db._task import _Task as _Task
 
 db = Database(DevelopmentConfig.SQLALCHEMY_DATABASE_URI)
@@ -68,7 +68,8 @@ def _convert_single_annotation(anno, username):
                                        label=label,
                                        user_id=user.id,
                                        context=anno["req"]["data"],
-                                       exclude_keys_in_retrieve=['context'])
+                                       source=AnnotationSource.ALCHMEY,
+                                       exclude_keys_in_retrieve=['context'],)
             return annotation.id
 
 

--- a/tests/integration/test_train_flow.py
+++ b/tests/integration/test_train_flow.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from db.model import (
     Task, ClassificationAnnotation, User, EntityTypeEnum,
-    majority_vote_annotations_query
-)
+    majority_vote_annotations_query,
+    AnnotationSource)
 from db.fs import RAW_DATA_DIR
 
 from train.no_deps.run import (
@@ -72,7 +72,7 @@ def _populate_db_and_fs(dbsession, tmp_path, N):
     # Create many Annotations for a Label
     def _create_anno(ent, v): return ClassificationAnnotation(
         entity_type=EntityTypeEnum.COMPANY, entity=ent, user=user,
-        label=LABEL, value=v)
+        label=LABEL, value=v, source=AnnotationSource.ALCHMEY)
 
     ents = [d['meta']['domain'] for d in data]
     annos = [

--- a/tests/unit/test_ar.py
+++ b/tests/unit/test_ar.py
@@ -2,8 +2,8 @@ from tests.sqlalchemy_conftest import *
 import ar
 from ar import Example
 from db.model import (
-    ClassificationAnnotation, get_or_create, User, LabelPatterns
-)
+    ClassificationAnnotation, get_or_create, User, LabelPatterns,
+    AnnotationSource)
 
 
 def test_assign_round_robin():
@@ -85,14 +85,16 @@ def populate_db(dbsession):
                                 entity=entity1,
                                 entity_type="company",
                                 label="b2c",
-                                user_id=user1.id)
+                                user_id=user1.id,
+                                source=AnnotationSource.ALCHMEY)
     annotation1 = get_or_create(dbsession=dbsession,
                                 model=ClassificationAnnotation,
                                 value=1,
                                 entity=entity1,
                                 entity_type="company",
                                 label="healthcare",
-                                user_id=user1.id)
+                                user_id=user1.id,
+                                source=AnnotationSource.ALCHMEY)
     user2 = get_or_create(dbsession=dbsession,
                           model=User,
                           username="user2")
@@ -102,7 +104,8 @@ def populate_db(dbsession):
                                 entity=entity2,
                                 entity_type="company",
                                 label="b2c",
-                                user_id=user2.id)
+                                user_id=user2.id,
+                                source=AnnotationSource.ALCHMEY)
     annotations = [annotation0, annotation1, annotation2]
     return user1, user2, annotations, entity1, entity2
 

--- a/tests/unit/test_ar_data.py
+++ b/tests/unit/test_ar_data.py
@@ -3,7 +3,7 @@ from ar.data import (
     _majority_label,
     _compute_total_distinct_number_of_annotated_entities_for_label
 )
-from db.model import User, ClassificationAnnotation
+from db.model import User, ClassificationAnnotation, AnnotationSource
 
 
 def test_majority_label():
@@ -21,7 +21,7 @@ def test__compute_total_distinct_number_of_annotated_entities_for_label(dbsessio
     def _anno(entity_type, entity, value, user):
         return ClassificationAnnotation(
             entity=entity, entity_type=entity_type, label='foo', value=value,
-            user=user)
+            user=user, source=AnnotationSource.ALCHMEY)
 
     # Add 3 distinct entities with labels, 2 with an unknown annotation.
     # Unknown annotations are not counted. So this should be 3.

--- a/tests/unit/test_classification_training_data.py
+++ b/tests/unit/test_classification_training_data.py
@@ -2,8 +2,8 @@ from tests.sqlalchemy_conftest import *
 from db.model import (
     User, ClassificationAnnotation,
     ClassificationTrainingData,
-    majority_vote_annotations_query
-)
+    majority_vote_annotations_query,
+    AnnotationSource)
 import os
 from db.fs import filestore_base_dir
 from shared.utils import load_jsonl
@@ -97,7 +97,8 @@ def _populate_db_variable(dbsession, n_users, n_entities):
                 entity_type=ENTITY_TYPE,
                 entity=ent, user=user, label=LABEL,
                 context={"text": f"abc{i}"},
-                value=1 if i % 2 else -1)
+                value=1 if i % 2 else -1,
+                source=AnnotationSource.ALCHMEY)
             annos.append(anno)
 
     dbsession.add_all(annos)

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -19,7 +19,7 @@ from ar.data import _compute_kappa_matrix, \
     _construct_comparison_df
 from db.model import User, ClassificationAnnotation, \
     AnnotationRequest, AnnotationType, AnnotationRequestStatus, Task, \
-    update_instance, AnnotationValue
+    update_instance, AnnotationValue, AnnotationSource
 
 ENTITY_TYPE = 'blah'
 
@@ -117,32 +117,39 @@ def _populate_annotation_data(dbsession):
     annotation1 = ClassificationAnnotation(value=1, user_id=user1.id,
                                            label=label1,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity1)
+                                           entity=entity1,
+                                           source=AnnotationSource.ALCHMEY)
     annotation2 = ClassificationAnnotation(value=1, user_id=user1.id,
                                            label=label1,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity2)
+                                           entity=entity2,
+                                           source=AnnotationSource.ALCHMEY)
     annotation3 = ClassificationAnnotation(value=-1, user_id=user1.id,
                                            label=label1,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity3)
+                                           entity=entity3,
+                                           source=AnnotationSource.ALCHMEY)
 
     annotation4 = ClassificationAnnotation(value=1, user_id=user2.id,
                                            label=label1,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity1)
+                                           entity=entity1,
+                                           source=AnnotationSource.ALCHMEY)
     annotation5 = ClassificationAnnotation(value=-1, user_id=user2.id,
                                            label=label1,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity2)
+                                           entity=entity2,
+                                           source=AnnotationSource.ALCHMEY)
     annotation6 = ClassificationAnnotation(value=-1, user_id=user3.id,
                                            label=label1,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity3)
+                                           entity=entity3,
+                                           source=AnnotationSource.ALCHMEY)
     annotation7 = ClassificationAnnotation(value=-1, user_id=user3.id,
                                            label=label2,
                                            entity_type=ENTITY_TYPE,
-                                           entity=entity3)
+                                           entity=entity3,
+                                           source=AnnotationSource.ALCHMEY)
 
     annotations = [
         annotation1, annotation2, annotation3, annotation4, annotation5,
@@ -468,7 +475,8 @@ def test__construct_comparison_df(dbsession):
         entity_type=entity_type,
         label=label,
         value=AnnotationValue.POSITIVE,
-        user_id=user1.id
+        user_id=user1.id,
+        source=AnnotationSource.ALCHMEY
     )
 
     annotation2 = ClassificationAnnotation(
@@ -476,7 +484,8 @@ def test__construct_comparison_df(dbsession):
         entity_type=entity_type,
         label=label,
         value=AnnotationValue.POSITIVE,
-        user_id=user1.id
+        user_id=user1.id,
+        source=AnnotationSource.ALCHMEY
     )
 
     # Annotations from user2
@@ -485,7 +494,8 @@ def test__construct_comparison_df(dbsession):
         entity_type=entity_type,
         label=label,
         value=AnnotationValue.POSITIVE,
-        user_id=user2.id
+        user_id=user2.id,
+        source=AnnotationSource.ALCHMEY
     )
 
     annotation4 = ClassificationAnnotation(
@@ -493,7 +503,8 @@ def test__construct_comparison_df(dbsession):
         entity_type=entity_type,
         label=label,
         value=AnnotationValue.NEGTIVE,
-        user_id=user2.id
+        user_id=user2.id,
+        source=AnnotationSource.ALCHMEY
     )
 
     # Annotations from user3
@@ -502,7 +513,8 @@ def test__construct_comparison_df(dbsession):
         entity_type=entity_type,
         label=label,
         value=AnnotationValue.UNSURE,
-        user_id=user3.id
+        user_id=user3.id,
+        source=AnnotationSource.ALCHMEY
     )
 
     dbsession.add_all([annotation1, annotation2, annotation3, annotation4,


### PR DESCRIPTION
Adding the source column. It may take two steps and this is the first one. For now I need to set source as nullable=True. Once we backfill the data, we can change it to be nullable=False. 

TODO: need to change some of the queries on existing annotations done by users on the website. Adding the source column as a filtering criterion.