### PR TITLE
Remove poll loop

### DIFF
--- a/train/gcp_celery.py
+++ b/train/gcp_celery.py
@@ -1,4 +1,4 @@
-import time
+import logging
 from typing import Optional
 from celery import Celery
 from train.gcp_job import GoogleAIPlatformJob, download
@@ -15,33 +15,59 @@ app = Celery(
     # backend='redis://localhost:6379/0',
 )
 
+# See all states at: https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#State
+RUNNING_STATES = ['QUEUED', 'PREPARING', 'RUNNING', 'CANCELLING',
+                  'STATE_UNSPECIFIED']
+TERMINAL_STATES = ['SUCCEEDED', 'FAILED', 'CANCELLED']
+
 
 @app.task
-def poll_status(job_id, metadata_dict: Optional[dict] = None):
+def poll_status(job_id: str, metadata_dict: Optional[dict] = None, poll_count: int = 0):
     """
     Inputs:
         job_id: GoogleAIPlatformJob job id
         metadata: Production metadata. If None, then this run shouldn't go into
             the production bucket.
+        poll_count: How many times did we poll already. Since we wait 60
+            seconds between polls, this tells use how long the job has been
+            running for, and we can use this to cancel runaway jobs.
     """
-    # TODO put this on a queue, rather than just a loop check.
-    while True:
-        job = GoogleAIPlatformJob.fetch(job_id)
+    logging.info(f"Poll AI Platform job_id={job_id}, poll_count={poll_count}")
 
-        if job is None:
-            raise Exception("Unknown job")
-        else:
-            if job.get_state() == 'SUCCEEDED':
-                for md in job.get_model_defns():
-                    download(md)
-                # TODO poll_status shouldn't have implementation details about callbacks
-                if metadata_dict:
-                    metadata = \
-                        DeployedInferenceMetadata.from_dict(metadata_dict)
-                    create_deployed_inference(metadata)
-                break
+    job = GoogleAIPlatformJob.fetch(job_id)
 
-        time.sleep(60)
+    if job is None:
+        raise Exception("Unknown job")
+    else:
+        job_state = job.get_state()
+        logging.info(f"job_state={job_state}")
+
+        if job_state == 'SUCCEEDED':
+            logging.info(f"Done AI Platform job_id={job_id}")
+            on_job_success(job, metadata_dict)
+        elif poll_count > 60:
+            # A job is taking too long. Try to cancel it.
+            try:
+                logging.info(f"Cancel AI Platform job_id={job_id}")
+                job.cancel()
+            except Exception:
+                # If an error occurred, we can try again later.
+                pass
+
+        if job_state in RUNNING_STATES:
+            # Check again in 60 seconds
+            poll_status.apply_async(args=[job_id, metadata_dict, poll_count+1],
+                                    countdown=60)
+
+
+def on_job_success(job: GoogleAIPlatformJob, metadata_dict: Optional[dict] = None):
+    # Sync down the model assets
+    for md in job.get_model_defns():
+        download(md)
+    # Deploy inferences to prod as needed
+    if metadata_dict:
+        metadata = DeployedInferenceMetadata.from_dict(metadata_dict)
+        create_deployed_inference(metadata)
 
 
 app.conf.task_routes = {'*.gcp_celery.*': {'queue': 'gcp_celery'}}

--- a/train/gcp_celery.py
+++ b/train/gcp_celery.py
@@ -50,7 +50,8 @@ def poll_status(job_id: str, metadata_dict: Optional[dict] = None, poll_count: i
             try:
                 logging.info(f"Cancel AI Platform job_id={job_id}")
                 job.cancel()
-            except Exception:
+            except Exception as e:
+                logging.error(f"Error in canceling job: {e}")
                 # If an error occurred, we can try again later.
                 pass
 

--- a/train/gcp_job.py
+++ b/train/gcp_job.py
@@ -282,11 +282,15 @@ class GoogleAIPlatformJob:
             },
             "trainingOutput": {}
         }
+
+        For all states, see:
+        https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#State
         """
         self.response = response or {}
 
     @classmethod
     def fetch(cls, job_id: str):
+        """This is the factory method to create GoogleAIPlatformJob objects"""
         cmd = f"gcloud ai-platform jobs describe {job_id} --format json"
 
         # TODO this is not best way to capture real error
@@ -337,6 +341,18 @@ class GoogleAIPlatformJob:
                 model_defns.append(md)
 
             return model_defns
+
+    def cancel(self) -> bool:
+        """Cancel a running job
+        Returns True if the job was cancelled successfully
+        Raises:
+            Exception if job_id is missing
+            Exception if a job has already completed
+        """
+        job_id = self.response.get("jobId")
+        assert job_id, "Cannot cancel job, missing job_id"
+        run_cmd(f'gcloud ai-platform jobs cancel {job_id}')
+        return True
 
 
 if __name__ == '__main__':

--- a/train/train_celery.py
+++ b/train/train_celery.py
@@ -132,7 +132,7 @@ def submit_gcp_inference_on_new_file(dataset_name):
 
 
 def submit_gcp_job(model: Model, files_for_inference: List[str],
-                   deploy_metadata: Optional[DeployedInferenceMetadata]):
+                   deploy_metadata: Optional[DeployedInferenceMetadata] = None):
     """Submits a training & inference job onto Google AI Platform.
 
     Inputs:


### PR DESCRIPTION
For checking the status of AI Platform jobs, we remove poll loop, and replace it with a job that's placed back onto the queue 60 seconds later.

This also cancels runaway jobs (jobs that take 1 hour or more).

Finally, this includes a stricter check on AI Platform job states, so the worker would only place itself back onto the queue if the AI Platform job is still in progress.