### PR TITLE
Rework logic of AR Examples and blacklists

### DIFF
--- a/ar/__init__.py
+++ b/ar/__init__.py
@@ -59,9 +59,7 @@ def get_nlp_models_for_label(dbsession, label):
 
 
 def get_ranked_examples_for_label(dbession, label, data_filenames) -> List[Example]:
-    """Get the ranking for each datapoint in data_filenames for this label.
-    (We're also passing in the task, but in the future I hope to remove this
-    dependency)
+    """Get examples in data_filenames for this label in ranked order.
     A lower ranking means higher desire to be labeled.
     """
     logging.info(f"Get prediction from label={label}")
@@ -356,10 +354,10 @@ def _get_decorated_example(pred: Example,
     return res
 
 
-def _build_blacklist_fn(lookup_set: set):
+def _build_blacklist_fn(lookup: set):
 
     def blacklist_fn(e: Example, user: str):
-        return LookupKey(e.entity_type, e.entity, e.label, user) in lookup_set
+        return LookupKey(e.entity_type, e.entity, e.label, user) in lookup
 
     return blacklist_fn
 

--- a/ar/__init__.py
+++ b/ar/__init__.py
@@ -19,11 +19,10 @@ from inference.nlp_model import (
     NLPModel, NLPModelTopResults, NLPModelBottomResults
 )
 
-from .data import fetch_all_ar_ids
-from .utils import get_ar_id, timeit
-
-Example = namedtuple('Example', ['score', 'entity', 'fname', 'line_number'])
-EntityUserTuple = namedtuple('EntityUserTuple', ['entity', 'user'])
+Example = namedtuple(
+    'Example', ['score', 'entity_type', 'entity', 'label', 'fname', 'line_number'])
+LookupKey = namedtuple(
+    'LookupKey', ['entity_type', 'entity', 'label', 'user'])
 
 
 def get_pattern_model_for_label(dbsession, label):
@@ -59,7 +58,7 @@ def get_nlp_models_for_label(dbsession, label):
     return highest_entropy_model, top_prob_model, bottom_prob_model
 
 
-def get_ranked_examples_for_label(dbession, task, label, data_filenames) -> List[Example]:
+def get_ranked_examples_for_label(dbession, label, data_filenames) -> List[Example]:
     """Get the ranking for each datapoint in data_filenames for this label.
     (We're also passing in the task, but in the future I hope to remove this
     dependency)
@@ -70,42 +69,47 @@ def get_ranked_examples_for_label(dbession, task, label, data_filenames) -> List
     examples: List[List[Example]] = []
     proportions: List[int] = []
 
+    # TODO do not hard-code
+    from db.model import EntityTypeEnum
+    entity_type = EntityTypeEnum.COMPANY
+
+    def get_examples_for_model(model: ITextCatModel):
+        return _get_examples(data_filenames, model, entity_type, label)
+
     # Random Examples
-    examples.append(_get_predictions(data_filenames, [RandomModel()]))
+    examples.append(get_examples_for_model(RandomModel()))
     proportions.append(1)
-    logging.info("Prediction from random model finished...")
+    logging.info("Prediction from random model finished")
 
     # Pattern-driven Examples
     _patterns_model = get_pattern_model_for_label(dbession, label)
     if _patterns_model:
-        examples.append(_get_predictions(data_filenames, [_patterns_model]))
+        examples.append(get_examples_for_model(_patterns_model))
         proportions.append(3)  # [1,3] -> [0.25, 0.75]
-        logging.info("Prediction from pattern model finished...")
+        logging.info("Prediction from pattern model finished")
 
     # NLP-driven Examples
     highest_entropy_model, top_prob_model, bottom_prob_model = \
         get_nlp_models_for_label(dbession, label)
+
     if highest_entropy_model:
-        examples.append(_get_predictions(
-            data_filenames, [highest_entropy_model]))
+        examples.append(get_examples_for_model(highest_entropy_model))
         proportions.append(12)  # [1,3,12] -> [0.0625, 0.1875, 0.75]
-        logging.info("Prediction from highest entropy nlp model finished...")
+        logging.info("Prediction from highest entropy nlp model finished")
 
     if top_prob_model:
-        examples.append(_get_predictions(
-            data_filenames, [top_prob_model]))
+        examples.append(get_examples_for_model(top_prob_model))
         proportions.append(6)  # [1,3,12,6] -> [0.05, 0.14, 0.55, 0.27]
-        logging.info("Prediction from top prob nlp model finished...")
+        logging.info("Prediction from top prob nlp model finished")
 
     if bottom_prob_model:
-        examples.append(_get_predictions(
-            data_filenames, [bottom_prob_model]))
+        examples.append(get_examples_for_model(bottom_prob_model))
         proportions.append(6)  # [1,3,12,6,6] -> [0.04, 0.11, 0.43, 0.21, 0.21]
-        logging.info("Prediction from bottom prob nlp model finished...")
+        logging.info("Prediction from bottom prob nlp model finished")
 
-    logging.error("Shuffling together examples...")
     ranked_examples = _shuffle_together_examples(
         examples, proportions=proportions)
+    logging.info("Shuffle together examples finished")
 
     return ranked_examples
 
@@ -162,8 +166,7 @@ def generate_annotation_requests(dbsession, task_id: int,
 
     ranked_examples_per_label = []
     for label in task.get_labels():
-        _res = get_ranked_examples_for_label(
-            dbsession, task, label, data_filenames)
+        _res = get_ranked_examples_for_label(dbsession, label, data_filenames)
         ranked_examples_per_label.append(_res)
 
     ranked_examples = consolidate_ranked_examples_per_label(
@@ -174,8 +177,8 @@ def generate_annotation_requests(dbsession, task_id: int,
     # be able to find if there are exisiting requests for this user and
     # entity under this task. If so, skip those.
     logging.info("Constructing blacklisting criteria...")
-    lookup_dict = _build_blacklisting_lookup_dict(dbsession=dbsession)
-    blacklist_fn = _build_blacklist_fn(lookup_dict=lookup_dict)
+    lookup = _build_blacklist_lookup(dbsession, task.get_labels())
+    blacklist_fn = _build_blacklist_fn(lookup)
 
     logging.info("Assigning to annotators...")
     assignments = _assign(ranked_examples,
@@ -310,22 +313,25 @@ def _merge_two_pattern_decors(pattern_decor1: List, pattern_decor2: List):
     return res
 
 
-def _build_blacklisting_lookup_dict(dbsession):
-    num_of_annotations_by_entity_and_user_within_task = \
+def _build_blacklist_lookup(dbsession, labels: List[str] = []) -> set:
+    existing_annotations_for_labels = \
         dbsession.query(
-            func.count(ClassificationAnnotation.id),
+            ClassificationAnnotation.entity_type,
             ClassificationAnnotation.entity,
+            ClassificationAnnotation.label,
             User.username
         ). \
         join(User). \
-        filter(ClassificationAnnotation.value !=
-               AnnotationValue.NOT_ANNOTATED). \
-        group_by(ClassificationAnnotation.entity, User.username).all()
-    lookup_dict = {
-        EntityUserTuple(item[1], item[2]): item[0]
-        for item in num_of_annotations_by_entity_and_user_within_task
-    }
-    return lookup_dict
+        filter(
+            ClassificationAnnotation.value != AnnotationValue.NOT_ANNOTATED,
+            ClassificationAnnotation.label.in_(labels)
+        ). \
+        distinct().all()
+    lookup = set([
+        LookupKey(item[0], item[1], item[2], item[3])
+        for item in existing_annotations_for_labels
+    ])
+    return lookup
 
 
 def _get_decorated_example(pred: Example,
@@ -350,52 +356,34 @@ def _get_decorated_example(pred: Example,
     return res
 
 
-def _build_blacklist_fn(lookup_dict: dict):
+def _build_blacklist_fn(lookup_set: set):
 
-    def blacklist_fn(pred: Example, annotator: str):
-        entity = pred.entity
-        lookup_key = EntityUserTuple(entity, annotator)
-        if lookup_key not in lookup_dict:
-            lookup_dict[lookup_key] = 0
-        return lookup_dict[lookup_key] > 0
+    def blacklist_fn(e: Example, user: str):
+        return LookupKey(e.entity_type, e.entity, e.label, user) in lookup_set
 
     return blacklist_fn
 
 
-def _get_predictions(data_filenames: List[str],
-                     models: List[ITextCatModel],
-                     cache=True) -> List[Example]:
-    '''
-    Return the aggregated score from all models for all lines in each
-    data_filenames
-
-    Return Example namedtuple (score, entity, fname, line_number)
-    '''
-    result = []
+def _get_examples(data_filenames: List[str], model: ITextCatModel,
+                  entity_type: str, label: str,
+                  cache=True) -> List[Example]:
+    '''Construct an Example based on the prediction of `model` on each of the
+    datasets.'''
+    examples = []
 
     for fname in data_filenames:
-        preds = []
-        metas = []
+        res = get_predicted(fname, model, cache=cache)
+        # TODO remove dependency on (fname,line_number)
+        for line_number, row in enumerate(res):
+            examples.append(Example(score=row['score'],
+                                    entity_type=entity_type,
+                                    # TODO remove dependency on meta.domain
+                                    entity=row['meta']['domain'],
+                                    label=label,
+                                    fname=fname,
+                                    line_number=line_number))
 
-        # TODO how can we obtain just one meta from res? If we have 3
-        #  models, we get 3 identical copy of entities right now.
-        for model in models:
-            res = get_predicted(fname, model, cache=cache)
-            preds.append([x['score'] for x in res])
-            metas.append([x['meta'] for x in res])
-
-        if len(preds) > 0:
-            # Get total score from all models.
-            total_scores = np.sum(preds, axis=0)
-            print(total_scores)
-
-            for line_number, score in enumerate(total_scores):
-                result.append(Example(score=score,
-                                      entity=metas[0][line_number]['domain'],
-                                      fname=fname,
-                                      line_number=line_number))
-
-    return result
+    return examples
 
 
 def _assign(datapoints: List, annotators: List,
@@ -472,8 +460,6 @@ def _assign(datapoints: List, annotators: List,
                 per_dp_queue[dp].append(anno)
                 per_anno_queue[anno].append(dp)
                 anno_q.put((len(per_anno_queue[anno]), anno))
-
-    # TODO insert random jobs to trade explore/exploit?
 
     return per_anno_queue
 

--- a/tests/unit/test_ar.py
+++ b/tests/unit/test_ar.py
@@ -73,66 +73,104 @@ def test_assign_blacklist():
 
 
 def populate_db(dbsession):
-    entity1 = "whatever1"
-    entity2 = "whatever2"
-    user1 = get_or_create(dbsession=dbsession,
-                          model=User,
-                          username="user1")
-    annotation0 = get_or_create(dbsession=dbsession,
-                                model=ClassificationAnnotation,
-                                value=1,
-                                entity=entity1,
-                                entity_type="company",
-                                label="b2c",
-                                user_id=user1.id)
-    annotation1 = get_or_create(dbsession=dbsession,
-                                model=ClassificationAnnotation,
-                                value=1,
-                                entity=entity1,
-                                entity_type="company",
-                                label="healthcare",
-                                user_id=user1.id)
-    user2 = get_or_create(dbsession=dbsession,
-                          model=User,
-                          username="user2")
-    annotation2 = get_or_create(dbsession=dbsession,
-                                model=ClassificationAnnotation,
-                                value=1,
-                                entity=entity2,
-                                entity_type="company",
-                                label="b2c",
-                                user_id=user2.id)
-    annotations = [annotation0, annotation1, annotation2]
-    return user1, user2, annotations, entity1, entity2
+    users = [
+        get_or_create(dbsession=dbsession, model=User, username='user0'),
+        get_or_create(dbsession=dbsession, model=User, username='user1'),
+    ]
+    entities = [
+        'entity0',
+        'entity1',
+    ]
+
+    def create_anno(user: User, entity: str, label: str, value: int):
+        instance = ClassificationAnnotation(
+            entity_type="blah",
+            entity=entity,
+            label=label,
+            value=value,
+            user_id=user.id
+        )
+        dbsession.add(instance)
+        dbsession.commit()
+
+    annotations = [
+        # Agreement
+        create_anno(users[0], entities[0], 'foo', 1),
+        create_anno(users[1], entities[0], 'foo', 1),
+
+        # Disagreement
+        create_anno(users[0], entities[1], 'foo', 1),
+        create_anno(users[1], entities[1], 'foo', -1),
+
+        # Duplicate
+        create_anno(users[0], entities[0], 'bar', 1),
+        create_anno(users[0], entities[0], 'bar', 1),
+    ]
+
+    return users, entities, annotations
 
 
-def test_build_blacklist_lookup_dict(dbsession):
-    user1, user2, annotations, _, _ = populate_db(dbsession)
-    lookup_dict = ar._build_blacklisting_lookup_dict(dbsession)
-    assert lookup_dict == {
-        ar.EntityUserTuple(annotations[0].entity, user1.username): 2,
-        ar.EntityUserTuple(annotations[2].entity, user2.username): 1,
-    }
+def test_build_blacklist_lookup(dbsession):
+    populate_db(dbsession)
+
+    def key(entity, label, user):
+        return ar.LookupKey(entity_type='blah', entity=entity, label=label, user=user)
+
+    lookup = ar._build_blacklist_lookup(dbsession, ['foo'])
+    foo_lookup = set({
+        key('entity0', 'foo', 'user0'),
+        key('entity0', 'foo', 'user1'),
+        key('entity1', 'foo', 'user0'),
+        key('entity1', 'foo', 'user1')
+    })
+    print(lookup)
+    print(foo_lookup)
+    assert lookup == foo_lookup
+
+    lookup = ar._build_blacklist_lookup(dbsession, ['bar'])
+    bar_lookup = set({
+        key('entity0', 'bar', 'user0')
+    })
+    assert lookup == bar_lookup
+
+    lookup = ar._build_blacklist_lookup(dbsession, ['foo', 'bar'])
+    assert lookup == foo_lookup.union(bar_lookup)
 
 
 def test_blacklisting_requests(dbsession):
-    user1, user2, annotations, entity1, entity2 = populate_db(dbsession)
-    dp1 = Example(score=1, entity="new_entity", fname="fname", line_number=1)
-    dp2 = Example(score=1, entity=entity1, fname="fname", line_number=1)
-    dp3 = Example(score=1, entity=entity2, fname="fname", line_number=1)
-    dp4 = Example(score=1, entity="entity_new", fname="fname", line_number=1)
-    datapoints = [dp1, dp2, dp3, dp4]
-    annotators = [user1.username, user2.username]
-    lookup_dict = ar._build_blacklisting_lookup_dict(dbsession=dbsession)
-    blacklist_fn = ar._build_blacklist_fn(lookup_dict=lookup_dict)
+    users, entities, annotations = populate_db(dbsession)
+
+    def create_dummy_example(entity, label):
+        return Example(score=1, entity_type="blah", entity=entity, label=label,
+                       fname="fname", line_number=1)
+
+    # Both users have annotated these entities with label='foo',
+    # So they should not be assigned again.
+    ex0 = create_dummy_example(entities[0], 'foo')
+    ex1 = create_dummy_example(entities[1], 'foo')
+
+    # Only users[0] has annotated entities[0] with label='bar',
+    # So it should not be assigned to users[0] again.
+    ex2 = create_dummy_example(entities[0], 'bar')
+    ex3 = create_dummy_example(entities[1], 'bar')
+
+    # New entity that has not been annotated by anyone yet.
+    ex4 = create_dummy_example('new_entity', 'foo')
+    ex5 = create_dummy_example('new_entity', 'bar')
+
+    examples = [ex0, ex1, ex2, ex3, ex4, ex5]
+
+    annotators = [user.username for user in users]
+    lookup = ar._build_blacklist_lookup(dbsession, ['foo', 'bar'])
+    blacklist_fn = ar._build_blacklist_fn(lookup)
 
     per_anno_queue = ar._assign(
-        datapoints, annotators, max_per_annotator=999, max_per_dp=999,
+        examples, annotators, max_per_annotator=999, max_per_dp=999,
         blacklist_fn=blacklist_fn)
 
     assert per_anno_queue == {
-        user1.username: [dp1, dp3, dp4],
-        user2.username: [dp1, dp2, dp4]
+        users[0].username: [ex3, ex4, ex5],
+        users[1].username: [ex2, ex3, ex4, ex5]
     }
 
 
@@ -171,14 +209,18 @@ def test_shuffle():
     def random_pred_class_a(linenum):
         return Example(
             score=0.1 + random.random()/100,
+            entity_type="blah",
             entity=str(linenum) + ".com",
+            label="foo",
             fname='data.jsonl',
             line_number=linenum)
 
     def random_pred_class_b(linenum):
         return Example(
             score=0.9 + random.random()/100,
+            entity_type="blah",
             entity=str(linenum) + ".com",
+            label="foo",
             fname='data.jsonl',
             line_number=linenum)
 
@@ -191,13 +233,17 @@ def test_shuffle_2():
     def random_pred_class_a(linenum):
         return Example(
             score=0.1,
+            entity_type="blah",
             entity=str(linenum) + ".com",
+            label="foo",
             fname='data.jsonl', line_number=linenum)
 
     def random_pred_class_b(linenum):
         return Example(
             score=0.9,
+            entity_type="blah",
             entity=str(linenum) + ".com",
+            label="foo",
             fname='data.jsonl',
             line_number=linenum)
 
@@ -208,7 +254,8 @@ def test_shuffle_2():
 
 def test__consolidate_ranked_examples_per_label__simple():
     def ex(entity):
-        return Example(score=0, entity=entity, fname='x', line_number=1)
+        return Example(score=0, entity_type="blah", entity=entity,
+                       label="foo", fname='x', line_number=1)
 
     # All labels assigned highest scores to 'c', then 'b', then 'a'.
     ranked_examples_per_label = [
@@ -223,7 +270,8 @@ def test__consolidate_ranked_examples_per_label__simple():
 
 def test__consolidate_ranked_examples_per_label__round_robin():
     def ex(entity):
-        return Example(score=0, entity=entity, fname='x', line_number=1)
+        return Example(score=0, entity_type="blah", entity=entity,
+                       label="foo", fname='x', line_number=1)
 
     # Round robin algo looks at the 1st column (a, a, c),
     # then 2nd col (b, c, a), and so on.


### PR DESCRIPTION
Fixes https://app.clickup.com/t/aamxdt

Also introduces a few cleanup changes:
1. `Example` now contains both `entity_type` and `label`. When we look up whether a user has annotated an example before (via the blacklist) we'll make use of both the `entity_type` and `label`.
2. `EntityUserTuple` is renamed to `LookupKey`, and also includes `entity_type` and `label`.
3. Simplified the blacklist SQL, and use a set instead of a dict.
4. Rename `_get_predictions` -> `_get_examples` and simplify.

All tests pass and also manually tested AR flow locally.