### PR TITLE
Use post request json param. 

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -47,13 +47,18 @@ def trigger_inference():
     """Trigger inference on a dataset."""
     dataset_name = None
 
-    if 'dataset_name' in request.form:
-        dataset_name = request.form.get('dataset_name')
+    json_data = request.get_json()
+
+    if json_data:
+        request_id = json_data.get('request_id')
+        logging.info("Handling request " + request_id)
+        dataset_name = json_data.get('dataset_name', None)
 
     if dataset_name:
         run_inference_on_data(dataset_name)
         return "OK", 200
     else:
+        logging.error(f"[{request_id}] Missing dataset name. Abort...")
         return abort(400)
 
 

--- a/cloud_function/inference/inference_api_invoker.py
+++ b/cloud_function/inference/inference_api_invoker.py
@@ -8,13 +8,10 @@ from google.cloud import storage, secretmanager
 
 
 def handler(request):
-    """Responds to any HTTP request.
+    """Responds to an HTTP request from a pubsub owned by GDP.
+
     Args:
         request (flask.Request): HTTP request object.
-    Returns:
-        The response text or any set of values that can be turned into a
-        Response object using
-        `make_response <http://flask.pocoo.org/docs/1.0/api/#flask.Flask.make_response>`.
     """
     request_json = request.get_json()
     message = None

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -8,14 +8,16 @@ def test_hc(backend_client):
     assert response.status == '200 OK'
 
 
-def make_request(backend_client, auth_token="test123", dataset_name="blah.jsonl"):
+def make_request(backend_client, auth_token="test123", dataset_name="blah.jsonl", request_id="R2D2"):
     url = '/api/trigger_inference'
     data = {}
     if dataset_name:
         data['dataset_name'] = dataset_name
+    if request_id:
+        data['request_id'] = request_id
     return backend_client.post(url, headers={
         'Authorization': f'Bearer {auth_token}'
-    }, data=data)
+    }, json=data)
 
 
 def test_authorized_call_token_not_set(backend_client, monkeypatch):


### PR DESCRIPTION
I have to change the function to use the `json` param in the `requests.post` method call. Somehow the form data does not show up (payload is empty) when I use the `data` param and it only happens with the cloud function in production. Locally the request works just fine. If you have some idea on why this is happening, please let me know.