### PR TITLE
Cache metrics computation

### DIFF
--- a/train/no_deps/metrics.py
+++ b/train/no_deps/metrics.py
@@ -122,12 +122,6 @@ def compute_metrics(version_dir, inference_lookup_df, threshold: float = 0.5):
     computed (e.g. if model has not been trained).
     """
 
-    # TODO: Refactoring model.export_inference to only depend on version_dir,
-    # then compute `inference_lookup_df` in this function.
-
-    # TODO cache this function or parts of it (especially inference_lookup_df).
-    # Unless we change the UI, performance will be an issue.
-
     config_fname = _get_config_fname(version_dir)
     data_fname = _get_exported_data_fname(version_dir)
 

--- a/train/no_deps/paths.py
+++ b/train/no_deps/paths.py
@@ -22,6 +22,11 @@ def _get_metrics_fname(version_dir):
     return os.path.join(version_dir, 'metrics.json')
 
 
+def _get_metrics_v2_fname(version_dir, threshold):
+    threshold = round(threshold, 8)
+    return os.path.join(version_dir, f'metrics_v2_threshold={threshold}.p')
+
+
 def _get_inference_dir(version_dir):
     # Note: We're responsible for creating this dir if it doesn't exist yet.
     dirname = os.path.join(version_dir, 'inference')


### PR DESCRIPTION
This is to fix a previous issue where computing the metrics of a model is slow, making the UI not useable.

Computing metrics is slow because it has to load in a bunch of files in order to find the predicted values of the train & test sets. (This could've been a lot simpler & faster if we had a different data storage design - a discussion we should have later)

After much deliberation, I've decided the best approach is to do the metrics computation on the first page load, cache the result on disk, so subsequent page loads are instant. This PR also includes some left-over refactoring.
